### PR TITLE
Don't mask API errors

### DIFF
--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -84,7 +84,7 @@ function initApplication(app) {
   return function(next) {
     app.get('stormpathClient').getApplication(app.get('stormpathApplication'), function(err, application) {
       if (err) {
-        throw new Error("ERROR: Couldn't find Stormpath application.");
+        throw err;
       }
 
       app.set('stormpathApplication', application);


### PR DESCRIPTION
This should throw the error which is given by the SDK, otherwise the programmer can not know what is causing the error.  For example, the programmer could have an invalid API Key file which causes a 401 Authentication error - but as written this will incorrectly throw "ERROR: Couldn't find Stormpath application."
