### PR TITLE
fix account verifications opts name

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -461,8 +461,8 @@ module.exports.initSettings = function(app, opts) {
     app.set('stormpathForgotPasswordEmailSentView', opts.forgotPasswordEmailSentView || process.env.STORMPATH_FORGOT_PASSWORD_EMAIL_SENT_VIEW || __dirname + '/views/forgot_email_sent.jade');
     app.set('stormpathForgotPasswordChangeView', opts.forgotPasswordChangeView || process.env.STORMPATH_FORGOT_PASSWORD_CHANGE_VIEW || __dirname + '/views/forgot_change.jade');
     app.set('stormpathForgotPasswordCompleteView', opts.forgotPasswordCompleteView || process.env.STORMPATH_FORGOT_PASSWORD_COMPLETE_VIEW || __dirname + '/views/forgot_complete.jade');
-    app.set('stormpathAccountVerificationEmailSentView', opts.forgotAccountVerificationEmailSentView || process.env.STORMPATH_ACCOUNT_VERIFICATION_EMAIL_SENT_VIEW || __dirname + '/views/verification_email_sent.jade');
-    app.set('stormpathAccountVerificationCompleteView', opts.forgotAccountVerificationCompleteView || process.env.STORMPATH_ACCOUNT_VERIFICATION_COMPLETE_VIEW || __dirname + '/views/verification_complete.jade');
+    app.set('stormpathAccountVerificationEmailSentView', opts.accountVerificationEmailSentView || process.env.STORMPATH_ACCOUNT_VERIFICATION_EMAIL_SENT_VIEW || __dirname + '/views/verification_email_sent.jade');
+    app.set('stormpathAccountVerificationCompleteView', opts.accountVerificationCompleteView || process.env.STORMPATH_ACCOUNT_VERIFICATION_COMPLETE_VIEW || __dirname + '/views/verification_complete.jade');
     app.set('stormpathUnauthorizedView', opts.unauthorizedView || process.env.STORMPATH_UNAUTHORIZED_VIEW || __dirname + '/views/unauthorized.jade');
 
     // Routing configuration.


### PR DESCRIPTION
Here's a fix for what it seems to be a wrong copy paste. We were wondering a lot why our templates weren't changing when setting `accountVerificationEmailSentView` in the options :).
