### PR TITLE
Add redirect urls after form submission

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -280,7 +280,7 @@ module.exports.forgot = function(req, res) {
         if (err) {
           helpers.render(view, res, { error: 'Invalid email address.', form: form });
         } else {
-          helpers.render(req.app.get('stormpathForgotPasswordEmailSentView'), res, { email: form.data.email });
+          res.redirect(req.app.get('stormpathPostForgotPasswordRedirectUrl'));
         }
       });
     },
@@ -299,6 +299,19 @@ module.exports.forgot = function(req, res) {
   });
 };
 
+/**
+ * This controller renders a page after forgot password to confirm that the 
+ * password reset email has been sent
+ *
+ * @method
+ *
+ * @param {Object} req - The http request.
+ * @param {Object} res - The http response.
+ */
+module.exports.forgotSent = function(req, res) {
+  res.locals.app = req.app;
+  helpers.render(req.app.get('stormpathForgotPasswordEmailSentView'), res);
+};
 
 /**
  * Allow a user to change his password.
@@ -337,7 +350,7 @@ module.exports.forgotChange = function(req, res) {
               if (err) {
                 helpers.render(view, res, { error: err.userMessage, form: form });
               } else {
-                helpers.render(req.app.get('stormpathForgotPasswordCompleteView'), res);
+                res.redirect(req.app.get('stormpathPostForgotPasswordChangeRedirectUrl'));                
               }
             })
           }
@@ -363,6 +376,19 @@ module.exports.forgotChange = function(req, res) {
       });
     }
   });
+};
+
+/**
+ * This controller renders a page to confirm that password reset is completed
+ *
+ * @method
+ *
+ * @param {Object} req - The http request.
+ * @param {Object} res - The http response.
+ */
+module.exports.forgotChangeDone = function(req, res) {
+  res.locals.app = req.app;
+  helpers.render(req.app.get('stormpathForgotPasswordCompleteView'), res);
 };
 
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -471,7 +471,9 @@ module.exports.initSettings = function(app, opts) {
     app.set('stormpathLogoutUrl', opts.logoutUrl || process.env.STORMPATH_LOGOUT_URL || '/logout');
     app.set('stormpathPostLogoutRedirectUrl', opts.postLogoutRedirectUrl || process.env.STORMPATH_POST_LOGOUT_REDIRECT_URL || '/');
     app.set('stormpathForgotPasswordUrl', opts.forgotPasswordUrl || process.env.STORMPATH_FORGOT_PASSWORD_URL || '/forgot');
+    app.set('stormpathPostForgotPasswordRedirectUrl', opts.postForgotPasswordRedirectUrl || process.env.STORMPATH_POST_FORGOT_PASSWORD_REDIRECT_URL || '/forgot/sent');
     app.set('stormpathForgotPasswordChangeUrl', opts.forgotPasswordChangeUrl || process.env.STORMPATH_FORGOT_PASSWORD_CHANGE_URL || '/forgot/change');
+    app.set('stormpathPostForgotPasswordChangeRedirectUrl', opts.postForgotPasswordChangeRedirectUrl || process.env.STORMPATH_POST_FORGOT_PASSWORD_CHANGE_REDIRECT_URL || '/forgot/change/done');
     app.set('stormpathAccountVerificationCompleteUrl', opts.accountVerificationCompleteUrl || process.env.STORMPATH_ACCOUNT_VERIFICATION_COMPLETE_URL || '/verified');
     app.set('stormpathGetOauthTokenUrl', opts.getOauthTokenUrl || process.env.STORMPATH_GET_OAUTH_TOKEN_URL || '/oauth');
     app.set('stormpathRedirectUrl', opts.redirectUrl || process.env.STORMPATH_REDIRECT_URL || '/');

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -200,12 +200,19 @@ module.exports.init = function(app, opts) {
   if (app.get('stormpathEnableForgotPassword')) {
     router.use(app.get('stormpathForgotPasswordUrl'), urlMiddleware);
     router.use(app.get('stormpathForgotPasswordChangeUrl'), urlMiddleware);
+    router.use(app.get('stormpathPostForgotPasswordChangeRedirectUrl'), urlMiddleware);
+    router.use(app.get('stormpathPostForgotPasswordRedirectUrl'), urlMiddleware);
+
     router.use(app.get('stormpathForgotPasswordUrl'), csrf());
     router.use(app.get('stormpathForgotPasswordChangeUrl'), csrf());
+    
     router.get(app.get('stormpathForgotPasswordChangeUrl'), controllers.forgotChange);
     router.post(app.get('stormpathForgotPasswordChangeUrl'), controllers.forgotChange);
+    router.get(app.get('stormpathPostForgotPasswordChangeRedirectUrl'), controllers.forgotChangeDone);
+    
     router.get(app.get('stormpathForgotPasswordUrl'), controllers.forgot);
     router.post(app.get('stormpathForgotPasswordUrl'), controllers.forgot);
+    router.get(app.get('stormpathPostForgotPasswordRedirectUrl'), controllers.forgotSent);
   }
 
   if (app.get('stormpathEnableAccountVerification')) {

--- a/lib/views/forgot_email_sent.jade
+++ b/lib/views/forgot_email_sent.jade
@@ -15,7 +15,7 @@ block body
               span.
                 Your password reset email has been sent!
               p.
-                We have sent a password reset email to your email
-                address: <b>#{email}</b>.
+                We have sent a password reset email to the email
+                address you have provided.
               p.
                 Please check your inbox to continue.


### PR DESCRIPTION
To prevent form resubmission, added a redirect and hooked view rendering on these new routes. Also allows customization of redirect url.
See best practice: http://en.wikipedia.org/wiki/Post/Redirect/Get
