### PR TITLE
added stormpathMiddleware on login route

### DIFF
--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -183,7 +183,7 @@ module.exports.init = function(app, opts) {
     if (app.get('stormpathEnableIdSite')) {
       router.get(app.get('stormpathLoginUrl'), controllers.idSiteLogin);
     } else {
-      router.use(app.get('stormpathLoginUrl'), urlMiddleware);
+      router.use(app.get('stormpathLoginUrl'), urlMiddleware, stormpathMiddleware);
       router.use(app.get('stormpathLoginUrl'), csrf());
       router.get(app.get('stormpathLoginUrl'), controllers.login);
       router.post(app.get('stormpathLoginUrl'), controllers.login);


### PR DESCRIPTION
The signin page needs the stormpathMiddleware to make the "auto-login if signed in" feature work. Here's the fix.

don't mind the branch name... I thought about adding it on each route like the urlMiddleware but there's only the login route that uses `req.user`.
