### PR TITLE
[WIP] add optional validation callbacks for all fields

### DIFF
--- a/lib/controllers.js
+++ b/lib/controllers.js
@@ -50,6 +50,34 @@ function assertRequired(req, res, form) {
   };
 }
 
+/**
+ * @return {Function} Return a function which accepts an account hash and a
+ *   callback.
+ */
+function checkValidations(req, res, form) {
+  var view = req.app.get('stormpathRegistrationView');
+  var validations = req.app.get('stormpathFieldValidations');
+
+  return function(callback) {
+    async.each(Object.keys(FIELDS), function(key, next) {
+      if (validations[key] && typeof validations[key] === 'function') {
+        var valid = validations[key].call(null, form.data[key]);
+        if (!valid) {
+          helpers.render(view, res, { error: FIELDS[key] + ' invalid.', form: form });
+          req.app.get('stormpathLogger').info('User submitted a form with an invalid key: ' + FIELDS[key] + '.');
+          next(new Error(FIELDS[key] + ' invalid.'));
+        } else {
+          next();
+        }
+      } else {
+        next();
+      }
+    }, function(err) {
+      callback(err);
+    });
+  };
+}
+
 
 /**
  * Build an account hash by inspecting the user submitted form, and retrieving
@@ -151,6 +179,7 @@ module.exports.register = function(req, res) {
     success: function(form) {
       async.waterfall([
         assertRequired(req, res, form),
+        checkValidations(req, res, form),
         buildAccount(req, form),
         createAccount(req, res, form),
       ], function(err) {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -204,6 +204,9 @@ module.exports.init = function(app, opts) {
   app.set('stormpathGoogleLoginUrl', opts.googleLoginUrl || process.env.STORMPATH_GOOGLE_LOGIN_URL || '/google');
   app.set('stormpathIdSiteUrl', opts.idSiteUrl || process.env.STORMPATH_ID_SITE_URL || '/redirect');
   app.set('stormpathIdSiteRegistrationUrl', opts.idSiteRegistrationUrl || process.env.STORMPATH_ID_SITE_REGISTRATION_URL || '/#register');
+
+  // extra validations
+  app.set('stormpathFieldValidations', opts.fieldValidations || {});
 };
 
 /**


### PR DESCRIPTION
Just opening this as an quick concept, would love some feedback on it. Working on a project right now, we would want to validate various fields before registration. For this example, check the user's email matches a certain domain set in an environment variable.

The idea is a simple object matching the fieldnames which would validate true or false any way the user wants.

signup-validations.js:
```javascript
var addrs = require('email-addresses');

function checkEmailDomain(email) {
  var mail = addrs.parseOneAddress(email);
  return mail.domain === process.env.DOMAIN;
});

module.exports = {
  email: checkEmailDomain
};
```

server.js:
```javascript
var stormpath = require('express-stormpath');
var signupValidations = require('./signup-validations.js');

// ...

app.use(stormpath.init(app, {
  application: process.env.STORMPATH_APP_HREF, 
  fieldValidations: signupValidations
}));

```

Could also improve this to return a validation message rather than a generic one.