### PR TITLE
Fixing /forgot JSON api, expects email

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,9 @@ Version 2.0.9
 **Not yet released.**
 
 - Fixing bug with customData expansion.
+- Fixing ``/forgot`` JSON endpoint to accept an ``email`` property.  Previously
+  was ``username`` but this is incorrect: the Stormpath API only accepts an
+  email address for the forgot password workflow.
 
 
 Version 2.0.8

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -11,7 +11,8 @@ Express-Stormpath releases.
 Version 2.0.8 -> Version 2.0.9
 ------------------------------
 
-**No changes needed!**
+If you are using the ``/forgot`` endpoint and posting JSON, you need to change
+the ``username`` property to ``email``
 
 
 Version 2.0.7 -> Version 2.0.8

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -12,7 +12,7 @@ Version 2.0.8 -> Version 2.0.9
 ------------------------------
 
 If you are using the ``/forgot`` endpoint and posting JSON, you need to change
-the ``username`` property to ``email``
+the ``username`` property to ``email``.
 
 
 Version 2.0.7 -> Version 2.0.8

--- a/lib/controllers/forgot-password.js
+++ b/lib/controllers/forgot-password.js
@@ -30,10 +30,8 @@ module.exports = function(req, res) {
   if (req.method === 'POST' && accepts === 'json') {
     return application.sendPasswordResetEmail(req.body.email, function(err) {
       if (err) {
-        logger.info('A user tried to reset their password, but supplied an invalid email address: ' + req.body.username + '.');
-        return res.status(400).json({ error: err.userMessage || err.message });
+        logger.info('A user tried to reset their password, but supplied an invalid email address: ' + req.body.email + '.');
       }
-
       res.end();
     });
   }

--- a/lib/controllers/forgot-password.js
+++ b/lib/controllers/forgot-password.js
@@ -28,7 +28,7 @@ module.exports = function(req, res) {
   res.locals.status = req.query.status;
 
   if (req.method === 'POST' && accepts === 'json') {
-    return application.sendPasswordResetEmail(req.body.username, function(err) {
+    return application.sendPasswordResetEmail(req.body.email, function(err) {
       if (err) {
         logger.info('A user tried to reset their password, but supplied an invalid email address: ' + req.body.username + '.');
         return res.status(400).json({ error: err.userMessage || err.message });

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -167,7 +167,7 @@ module.exports.init = function(app, opts) {
         router.get(config.web.forgotPassword.uri, controllers.idSiteRedirect({ path: config.web.idSite.forgotUri }));
       } else {
         router.get(config.web.forgotPassword.uri, controllers.forgotPassword);
-        router.post(config.web.forgotPassword.uri, controllers.forgotPassword);
+        router.post(config.web.forgotPassword.uri, bodyParser.json({ limit: '200kb' }), controllers.forgotPassword);
       }
     }
 

--- a/test/controllers/test-forgot-password.js
+++ b/test/controllers/test-forgot-password.js
@@ -169,4 +169,29 @@ describe('forgotPassword', function() {
         .expect(302, done);
     });
   });
+
+  describe('as json',function(){
+
+    it('should respond with 200 if a valid email is given', function(done){
+       var app = helpers.createStormpathExpressApp({
+        application: {
+          href: stormpathApplication.href,
+        },
+        web: {
+          forgotPassword: {
+            enabled: true
+          }
+        }
+      });
+      app.on('stormpath.ready', function() {
+        request(app)
+          .post('/forgot')
+          .set('Accept', 'application/json')
+          .type('json')
+          .send({ email: uuid.v4() + '@stormpath.com' })
+          .expect(200, done);
+      });
+    });
+
+  });
 });

--- a/test/controllers/test-forgot-password.js
+++ b/test/controllers/test-forgot-password.js
@@ -173,9 +173,9 @@ describe('forgotPassword', function() {
   describe('as json',function(){
 
     it('should respond with 200 if a valid email is given', function(done){
-       var app = helpers.createStormpathExpressApp({
+      var app = helpers.createStormpathExpressApp({
         application: {
-          href: stormpathApplication.href,
+          href: stormpathApplication.href
         },
         web: {
           forgotPassword: {
@@ -183,6 +183,7 @@ describe('forgotPassword', function() {
           }
         }
       });
+
       app.on('stormpath.ready', function() {
         request(app)
           .post('/forgot')
@@ -192,6 +193,5 @@ describe('forgotPassword', function() {
           .expect(200, done);
       });
     });
-
   });
 });


### PR DESCRIPTION
This endpoint was expecting a `username` property, but this is not correct.  It should be `email`.  The Stormpath API only accepts email for password reset.