### PR TITLE
Fixing post-login and post-registration handlers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,9 +7,12 @@ Change Log
 All library changes, in descending order.
 
 Version 2.0.10
--------------
+--------------
 
-**Not yet released.**
+**Not yet released**
+
+- Fixing the ``postRegistrationHandler``, it is now called even if ``config.web.register.autoLogin`` is ``false``.  It now receives an expanded account object.
+- Fixing the ``postLoginHandler``, it now receives an expanded account object.
 
 Version 2.0.9
 -------------

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -10,7 +10,7 @@ Express-Stormpath releases.
 Version 2.0.9 -> Version 2.0.10
 -------------------------------
 
-We were looking for the option ``config.web.regisgter.autoAuthorize``, to
+We were looking for the option ``config.web.register.autoAuthorize``, to
 enable the auto-login-after-registration feature.   This should actually be
 ``autoLogin``, and it is documented as this. The library is now looking for
 this option as ``autoLogin``, so you will need to change your configuration it

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -7,6 +7,15 @@ Upgrade Guide
 This page contains specific upgrading instructions to help you migrate between
 Express-Stormpath releases.
 
+Version 2.0.9 -> Version 2.0.10
+-------------------------------
+
+We were looking for the option ``config.web.regisgter.autoAuthorize``, to
+enable the auto-login-after-registration feature.   This should actually be
+``autoLogin``, and it is documented as this. The library is now looking for
+this option as ``autoLogin``, so you will need to change your configuration it
+if you were using ``autoAuthorize``.
+
 
 Version 2.0.8 -> Version 2.0.9
 ------------------------------

--- a/lib/controllers/login.js
+++ b/lib/controllers/login.js
@@ -6,7 +6,7 @@ var uuid = require('uuid');
 
 var forms = require('../forms');
 var helpers = require('../helpers');
-var oauth = require('../oauth')
+var oauth = require('../oauth');
 
 /**
  * This controller logs in an existing user.  If there are any errors, an

--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -56,9 +56,8 @@ function defaultAutoAuthorizeHtmlResponse(config,req,res){
 
 /**
  * Delivers the default response for registration attempts that accept a JSON
- * content type, where the new account is in a verified state and the config
- * has requested that we automatically log in the user. In this situation we
- * simply return the user object as JSON
+ * content type. In this situation we simply return the new account object as
+ * JSON
  *
  * @function
  *
@@ -66,7 +65,7 @@ function defaultAutoAuthorizeHtmlResponse(config,req,res){
  * @param {Object} req - The http request.
  * @param {Object} res - The http response.
  */
-function defaultAutoAuthorizeJsonResponse(req,res){
+function defaultJsonResponse(req,res){
   res.json(req.user);
 }
 
@@ -111,18 +110,18 @@ module.exports = function(req, res) {
                 if (err) {
                   return res.status(400).json({ errors: [new Error(err.userMessage || err.message)] });
                 }
-                helpers.createSession(passwordGrantAuthenticationResult, account, req, res);
+                helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
                 if (postRegistrationHandler) {
-                  return postRegistrationHandler(req.user, req, res, defaultAutoAuthorizeJsonResponse.bind(null,req,res));
+                  return postRegistrationHandler(expandedAccount, req, res, defaultJsonResponse.bind(null,req,res));
                 }
-                defaultAutoAuthorizeJsonResponse(req,res);
+                defaultJsonResponse(req,res);
               });
             }
 
             if (postRegistrationHandler) {
-              return postRegistrationHandler(req.user, req, res, defaultAutoAuthorizeJsonResponse.bind(null,req,res));
+              return postRegistrationHandler(expandedAccount, req, res, defaultJsonResponse.bind(null,req,res));
             }
-            defaultAutoAuthorizeJsonResponse(req,res);
+            defaultJsonResponse(req,res);
           });
 
         });
@@ -198,12 +197,12 @@ module.exports = function(req, res) {
       // user on the login page.
 
       helpers.expandAccount(req.app,account,function(err,expandedAccount){
-        req.user = account = expandedAccount;
+        req.user = expandedAccount;
 
-        if (account.status === 'UNVERIFIED') {
+        if (expandedAccount.status === 'UNVERIFIED') {
 
           if (postRegistrationHandler) {
-            return postRegistrationHandler(req.user, req, res, defaultUnverifiedHtmlResponse.bind(null,config,res));
+            return postRegistrationHandler(expandedAccount, req, res, defaultUnverifiedHtmlResponse.bind(null,config,res));
           }
           return defaultUnverifiedHtmlResponse(config,res);
         }
@@ -216,16 +215,16 @@ module.exports = function(req, res) {
             if (err) {
               return res.status(400).json({ errors: [new Error(err.userMessage || err.message)] });
             }
-            helpers.createSession(passwordGrantAuthenticationResult, account, req, res);
+            helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
             if (postRegistrationHandler) {
-              return postRegistrationHandler(req.user, req, res, defaultAutoAuthorizeHtmlResponse.bind(null,config,req,res));
+              return postRegistrationHandler(expandedAccount, req, res, defaultAutoAuthorizeHtmlResponse.bind(null,config,req,res));
             }
             defaultAutoAuthorizeHtmlResponse(config,req,res);
           });
         }
 
         if (postRegistrationHandler) {
-          return postRegistrationHandler(req.user, req, res, function() {
+          return postRegistrationHandler(expandedAccount, req, res, function() {
             return defaultCreatedHtmlResponse(config,res);
           });
         }

--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -7,6 +7,70 @@ var uuid = require('uuid');
 var helpers = require('../helpers');
 
 /**
+ * Delivers the default response for registration attempts that accept an HTML
+ * content type, where the new account is in an unverified state. In this
+ * situation we redirect to the login page with a query parameter that
+ * indidcates that the account is unverified
+ *
+ * @function
+ *
+ * @param {Object} config - The express-stormpath configuration object
+ * @param {Object} res - The http response.
+ */
+function defaultUnverifiedHtmlResponse(config,res){
+  res.redirect(302, config.web.login.uri + '?status=unverified');
+}
+
+/**
+ * Delivers the default response for registration attempts that accept an HTML
+ * content type, where the new account is in a verified state. In this
+ * situation we redirect to the login page with a query parameter that
+ * indidcates that the account has been created (and is ready for a login
+ * attempt)
+ *
+ * @function
+ *
+ * @param {Object} config - The express-stormpath configuration object
+ * @param {Object} res - The http response.
+ */
+function defaultCreatedHtmlResponse(config,res){
+  res.redirect(302, config.web.login.uri + '?status=created');
+}
+
+/**
+ * Delivers the default response for registration attempts that accept an HTML
+ * content type, where the new account is in a verified state and the config
+ * has requested that we automatically log in the user. In this situation we
+ * redirect to the next URI that is in the url, or the nextUri that is defined
+ * on the registration configuration
+ *
+ * @function
+ *
+ * @param {Object} config - The express-stormpath configuration object
+ * @param {Object} req - The http request.
+ * @param {Object} res - The http response.
+ */
+function defaultAutoAuthorizeHtmlResponse(config,req,res){
+  res.redirect(302, req.query.next || config.web.register.nextUri);
+}
+
+/**
+ * Delivers the default response for registration attempts that accept a JSON
+ * content type, where the new account is in a verified state and the config
+ * has requested that we automatically log in the user. In this situation we
+ * simply return the user object as JSON
+ *
+ * @function
+ *
+ * @param {Object} config - The express-stormpath configuration object
+ * @param {Object} req - The http request.
+ * @param {Object} res - The http response.
+ */
+function defaultAutoAuthorizeJsonResponse(req,res){
+  res.json(req.user);
+}
+
+/**
  * Register a new user -- either via a JSON API, or via a browser.
  *
  * @method
@@ -21,7 +85,6 @@ module.exports = function(req, res) {
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
   var postRegistrationHandler = config.postRegistrationHandler;
-  var next = config.web.register.nextUri;
   var view = config.web.register.view;
 
   // Handle incoming POST requests from an API-like clients (something like
@@ -37,8 +100,31 @@ module.exports = function(req, res) {
           if (err) {
             return res.status(400).json({ error: err.userMessage || err.message });
           }
+          helpers.expandAccount(req.app,account,function(err,expandedAccount){
+            req.user = expandedAccount;
 
-          res.json(account);
+            if (config.web.register.autoLogin) {
+              return authenticator.authenticate({
+                username: req.body.email || uuid(),
+                password: req.body.password || uuid()
+              }, function(err, passwordGrantAuthenticationResult) {
+                if (err) {
+                  return res.status(400).json({ errors: [new Error(err.userMessage || err.message)] });
+                }
+                helpers.createSession(passwordGrantAuthenticationResult, account, req, res);
+                if (postRegistrationHandler) {
+                  return postRegistrationHandler(req.user, req, res, defaultAutoAuthorizeJsonResponse.bind(null,req,res));
+                }
+                defaultAutoAuthorizeJsonResponse(req,res);
+              });
+            }
+
+            if (postRegistrationHandler) {
+              return postRegistrationHandler(req.user, req, res, defaultAutoAuthorizeJsonResponse.bind(null,req,res));
+            }
+            defaultAutoAuthorizeJsonResponse(req,res);
+          });
+
         });
       });
     });
@@ -108,34 +194,45 @@ module.exports = function(req, res) {
         logger.info(err);
         return helpers.render(req, res, view, { errors: [new Error(err.userMessage)], form: helpers.sanitizeFormData(req.body, config) });
       }
-
       // If the account is unverified, we'll show a special message to the
       // user on the login page.
-      if (account.status === 'UNVERIFIED') {
-        return res.redirect(302, config.web.login.uri + '?status=unverified');
-      }
 
-      if (config.web.register.autoAuthorize) {
-        return authenticator.authenticate({
-          username: req.body.email || uuid(),
-          password: req.body.password || uuid()
-        }, function(err, passwordGrantAuthenticationResult) {
-          if (err) {
-            return res.status(400).json({ errors: [new Error(err.userMessage || err.message)] });
-          }
+      helpers.expandAccount(req.app,account,function(err,expandedAccount){
+        req.user = account = expandedAccount;
 
-          helpers.createSession(passwordGrantAuthenticationResult, account, req, res);
+        if (account.status === 'UNVERIFIED') {
+
           if (postRegistrationHandler) {
-            return postRegistrationHandler(req.user, req, res, function() {
-              res.redirect(302, req.query.next || next);
-            });
+            return postRegistrationHandler(req.user, req, res, defaultUnverifiedHtmlResponse.bind(null,config,res));
           }
+          return defaultUnverifiedHtmlResponse(config,res);
+        }
 
-          res.redirect(302, req.query.next || next);
-        });
-      }
+        if (config.web.register.autoLogin) {
+          return authenticator.authenticate({
+            username: req.body.email || uuid(),
+            password: req.body.password || uuid()
+          }, function(err, passwordGrantAuthenticationResult) {
+            if (err) {
+              return res.status(400).json({ errors: [new Error(err.userMessage || err.message)] });
+            }
+            helpers.createSession(passwordGrantAuthenticationResult, account, req, res);
+            if (postRegistrationHandler) {
+              return postRegistrationHandler(req.user, req, res, defaultAutoAuthorizeHtmlResponse.bind(null,config,req,res));
+            }
+            defaultAutoAuthorizeHtmlResponse(config,req,res);
+          });
+        }
 
-      res.redirect(302, config.web.login.uri + '?status=created');
+        if (postRegistrationHandler) {
+          return postRegistrationHandler(req.user, req, res, function() {
+            return defaultCreatedHtmlResponse(config,res);
+          });
+        }
+        return defaultCreatedHtmlResponse(config,res);
+
+
+      });
     });
   } else {
     res.status(415).end();

--- a/lib/helpers/login-responder.js
+++ b/lib/helpers/login-responder.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var createSession = require('./create-session');
+var expandAccount = require('./expand-account');
 
 module.exports = function(passwordGrantAuthenticationResult, account, req, res) {
   var accepts = req.accepts(['html','json']);
@@ -8,23 +9,26 @@ module.exports = function(passwordGrantAuthenticationResult, account, req, res) 
   var postLoginHandler = config.postLoginHandler;
   var redirectUrl = config.web.login.nextUri;
 
-  createSession(passwordGrantAuthenticationResult, account, req, res);
+  expandAccount(req.app,account,function(err,expandedAccount){
+    req.user = expandedAccount;
+    createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
 
-  if (postLoginHandler) {
-    return postLoginHandler(req.user, req, res, function() {
-      if (accepts === 'json') {
-        return res.end();
-      }
+    if (postLoginHandler) {
+      return postLoginHandler(req.user, req, res, function() {
+        if (accepts === 'json') {
+          return res.end();
+        }
 
-      var url = req.query.next || redirectUrl;
-      res.redirect(302, url);
-    });
-  }
+        var url = req.query.next || redirectUrl;
+        res.redirect(302, url);
+      });
+    }
 
-  if (accepts === 'json') {
-    return res.end();
-  }
+    if (accepts === 'json') {
+      return res.end();
+    }
 
-  var url = req.query.next || redirectUrl;
-  res.redirect(302, url);
+    var url = req.query.next || redirectUrl;
+    res.redirect(302, url);
+  });
 };

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -153,7 +153,7 @@ module.exports.init = function(app, opts) {
       if (provider.enabled) {
         var controllerName = providerName + 'Login';
         if (controllerName in controllers) {
-          router.get(provider.callbackUri, controllers[controllerName])
+          router.get(provider.callbackUri, controllers[controllerName]);
         }
       }
     }

--- a/test/controllers/test-register.js
+++ b/test/controllers/test-register.js
@@ -1,16 +1,13 @@
 'use strict';
 
-var fs = require('fs');
-
 var assert = require('assert');
 var async = require('async');
 var cheerio = require('cheerio');
-var express = require('express');
+var fs = require('fs');
 var request = require('supertest');
 var uuid = require('uuid');
 
 var helpers = require('../helpers');
-var stormpath = require('../../index');
 
 describe('register', function() {
   var stormpathApplication;
@@ -847,7 +844,7 @@ describe('register', function() {
         },
         web: {
           register: {
-            autoAuthorize: true,
+            autoLogin: true,
             enabled: true,
             nextUri: '/woot'
           }
@@ -885,7 +882,7 @@ describe('register', function() {
         },
         web: {
           register: {
-            autoAuthorize: true,
+            autoLogin: true,
             enabled: true,
             nextUri: '/woot'
           }
@@ -916,7 +913,7 @@ describe('register', function() {
       });
     });
 
-    it('should redirect the user to the login page with ?status=created if autoAuthorize is not enabled', function(done) {
+    it('should redirect the user to the login page with ?status=created if autoLogin is not enabled', function(done) {
       var app = helpers.createStormpathExpressApp({
         application: {
           href: stormpathApplication.href

--- a/test/handlers/test-me.js
+++ b/test/handlers/test-me.js
@@ -1,0 +1,82 @@
+'use strict';
+
+var assert = require('assert');
+var request = require('supertest');
+var uuid = require('uuid');
+
+var helpers = require('../helpers');
+
+function prepateMeTestFixture(stormpathApplication,cb){
+
+  var app = helpers.createStormpathExpressApp({
+    application: stormpathApplication,
+    website: true,
+    expand: {
+      customData: true
+    },
+    web: {
+      me: {
+        enabled: true
+      }
+    }
+  });
+
+  var fixture = {
+    expressApp: app
+  };
+
+  app.on('stormpath.ready', cb.bind(null,fixture));
+}
+
+describe('current user (/me) route',function() {
+
+  var newUser = helpers.newUser();
+  var stormpathApplication = null;
+
+  newUser.customData = {
+    favoriteColor: uuid.v4()
+  };
+
+  before(function(done) {
+    helpers.createApplication(helpers.createClient(), function(err, app) {
+      if (err) {
+        return done(err);
+      }
+
+      stormpathApplication = app;
+      app.createAccount(newUser, done);
+    });
+  });
+
+  it('should respond with the expanded account object',function(done){
+    prepateMeTestFixture(stormpathApplication,function(fixture){
+      var agent = request.agent(fixture.expressApp);
+      agent
+        .post('/login')
+        .set('Accept', 'application/json')
+        .type('json')
+        .send({username: newUser.email, password: newUser.password})
+        .end(function(err) {
+          if (err) {
+            return done(err);
+          }
+
+          /**
+           * The agent now has the cookies that will allow us to request the
+           * /me route
+           */
+
+          agent
+            .get('/me')
+            .expect(200)
+            .end(function(err,res){
+              if (err) {
+                return done(err);
+              }
+              assert(res.body.customData.favoriteColor === newUser.customData.favoriteColor);
+              done();
+            });
+        });
+    });
+  });
+});

--- a/test/handlers/test-post-login-handler.js
+++ b/test/handlers/test-post-login-handler.js
@@ -1,0 +1,157 @@
+'use strict';
+
+var assert = require('assert');
+var request = require('supertest');
+var uuid = require('uuid');
+
+var helpers = require('../helpers');
+
+function preparePostLoginExpansionTestFixture(stormpathApplication,cb){
+
+  var app = helpers.createStormpathExpressApp({
+    application: stormpathApplication,
+    website: true,
+    expand: {
+      customData: true
+    },
+    postLoginHandler: function(account,req,res){
+      // Simply return the user object, so that we can
+      // assert that the custom data was expanded
+      res.json(account);
+    }
+  });
+
+  var fixture = {
+    expressApp: app
+  };
+
+  app.on('stormpath.ready', cb.bind(null,fixture));
+}
+
+function preparePostLoginPassThroughTestFixture(stormpathApplication,cb){
+
+  var sideEffectData = uuid.v4();
+
+  var app = helpers.createStormpathExpressApp({
+    application: stormpathApplication,
+    website: true,
+    postLoginHandler: function(account,req,res,next){
+      fixture.sideEffect = sideEffectData;
+      next();
+    }
+  });
+
+  var fixture = {
+    expressApp: app,
+    sideEffectData: sideEffectData,
+    sideEffect: null
+  };
+
+  app.on('stormpath.ready', cb.bind(null,fixture));
+}
+
+describe('Post-Login Handler',function() {
+
+  var stormpathApplication = null;
+  var newUser = helpers.newUser();
+
+  newUser.customData = {
+    favoriteColor: uuid.v4()
+  };
+
+  before(function(done) {
+    helpers.createApplication(helpers.createClient(), function(err, app) {
+      if (err) {
+        return done(err);
+      }
+
+      stormpathApplication = app;
+      stormpathApplication.createAccount(newUser,done);
+    });
+  });
+
+  describe('with a JSON post',function(){
+
+    it('should be given the expanded account object',function(done){
+
+      preparePostLoginExpansionTestFixture(stormpathApplication,function(fixture){
+        request(fixture.expressApp)
+          .post('/login')
+          .set('Accept', 'application/json')
+          .type('json')
+          .send({username: newUser.email, password: newUser.password})
+          .expect('Set-Cookie', /access_token=[^;]+/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            assert(res.body.customData.favoriteColor === newUser.customData.favoriteColor);
+            done();
+          });
+      });
+    });
+
+    it('should allow me to do work, then call next (let framework end the response)',function(done){
+
+      preparePostLoginPassThroughTestFixture(stormpathApplication,function(fixture){
+        request(fixture.expressApp)
+          .post('/login')
+          .set('Accept', 'application/json')
+          .type('json')
+          .send({username: newUser.email, password: newUser.password})
+          .expect('Set-Cookie', /access_token=[^;]+/)
+          .expect(200)
+          .end(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            assert(fixture.sideEffect === fixture.sideEffectData);
+            done();
+          });
+      });
+    });
+  });
+
+  describe('with a Form-Encoded post',function(){
+
+    it('should be given the expanded account object',function(done){
+
+      preparePostLoginExpansionTestFixture(stormpathApplication,function(fixture){
+        request(fixture.expressApp)
+          .post('/login')
+          .send({login: newUser.email, password: newUser.password})
+          .expect('Set-Cookie', /access_token=[^;]+/)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            assert(res.body.customData.favoriteColor === newUser.customData.favoriteColor);
+            done();
+          });
+      });
+    });
+
+    it('should allow me to do work, then call next (let framework end the response)',function(done){
+
+      preparePostLoginPassThroughTestFixture(stormpathApplication,function(fixture){
+        request(fixture.expressApp)
+          .post('/login')
+          .send({login: newUser.email, password: newUser.password})
+          .expect('Set-Cookie', /access_token=[^;]+/)
+          .expect(302)
+          .end(function(err) {
+            if (err) {
+              return done(err);
+            }
+            assert(fixture.sideEffect === fixture.sideEffectData);
+            done();
+          });
+      });
+    });
+  });
+});

--- a/test/handlers/test-post-registration-handler.js
+++ b/test/handlers/test-post-registration-handler.js
@@ -107,7 +107,6 @@ describe('Post-Registration Handler',function() {
     it('should be given the expanded account object',function(done){
 
       preparePostRegistrationExpansionTestFixture(stormpathApplication,function(fixture){
-
         request(fixture.expressApp)
           .post('/register')
           .set('Accept', 'application/json')
@@ -126,6 +125,7 @@ describe('Post-Registration Handler',function() {
     });
 
     it('should allow me to do work, then call next (let framework end the response)',function(done){
+
       preparePostRegistrationPassThroughTestFixture(stormpathApplication,function(fixture){
         request(fixture.expressApp)
           .post('/register')
@@ -145,6 +145,7 @@ describe('Post-Registration Handler',function() {
     });
 
     it('shoud call the postRegistrationHandler, even if autoLogin is true',function(done){
+
       preparePostRegistrationAutoLoginTestFixture(stormpathApplication,function(fixture){
         request(fixture.expressApp)
           .post('/register')
@@ -153,7 +154,7 @@ describe('Post-Registration Handler',function() {
           .send(fixture.newAccountObject)
           .expect('Set-Cookie', /access_token=[^;]+/)
           .expect(200)
-          .end(function(err,res) {
+          .end(function(err) {
             if (err) {
               return done(err);
             }
@@ -164,9 +165,11 @@ describe('Post-Registration Handler',function() {
       });
     });
   });
+
   describe('with a Form-Encoded post',function(){
 
     it('should be given the expanded account object',function(done){
+
       preparePostRegistrationExpansionTestFixture(stormpathApplication,function(fixture){
         request(fixture.expressApp)
           .post('/register')
@@ -176,6 +179,7 @@ describe('Post-Registration Handler',function() {
             if (err) {
               return done(err);
             }
+
             assert(res.body.customData.favoriteColor === fixture.newAccountObject.favoriteColor);
             done();
           });
@@ -183,6 +187,7 @@ describe('Post-Registration Handler',function() {
     });
 
     it('should allow me to do work, then call next (let framework end the response)',function(done){
+
       preparePostRegistrationPassThroughTestFixture(stormpathApplication,function(fixture){
         request(fixture.expressApp)
           .post('/register')
@@ -192,12 +197,15 @@ describe('Post-Registration Handler',function() {
             if (err) {
               return done(err);
             }
+
             assert(fixture.sideEffect === fixture.sideEffectData);
             done();
           });
       });
     });
+
     it('shoud call the postRegistrationHandler, even if autoLogin is true',function(done){
+
       preparePostRegistrationAutoLoginTestFixture(stormpathApplication,function(fixture){
         request(fixture.expressApp)
           .post('/register')

--- a/test/handlers/test-post-registration-handler.js
+++ b/test/handlers/test-post-registration-handler.js
@@ -1,0 +1,218 @@
+'use strict';
+
+var assert = require('assert');
+var request = require('supertest');
+var uuid = require('uuid');
+
+var helpers = require('../helpers');
+
+function preparePostRegistrationExpansionTestFixture(stormpathApplication,cb){
+
+  var newAccount = helpers.newUser();
+
+  newAccount.favoriteColor = uuid.v4();
+
+  var app = helpers.createStormpathExpressApp({
+    application: stormpathApplication,
+    website: true,
+    expand: {
+      customData: true
+    },
+    postRegistrationHandler: function(account,req,res){
+      // Simply return the user object, so that we can
+      // assert that the custom data was expanded
+      res.json(account);
+    }
+  });
+
+  var fixture = {
+    expressApp: app,
+    newAccountObject: newAccount
+  };
+
+  app.on('stormpath.ready', cb.bind(null,fixture));
+}
+
+function preparePostRegistrationPassThroughTestFixture(stormpathApplication,cb){
+
+  var newAccount = helpers.newUser();
+
+  var sideEffectData = uuid.v4();
+
+  var app = helpers.createStormpathExpressApp({
+    application: stormpathApplication,
+    website: true,
+    postRegistrationHandler: function(account,req,res,next){
+      fixture.sideEffect = sideEffectData;
+      next();
+    }
+  });
+
+  var fixture = {
+    expressApp: app,
+    newAccountObject: newAccount,
+    sideEffectData: sideEffectData,
+    sideEffect: null
+  };
+
+  app.on('stormpath.ready', cb.bind(null,fixture));
+}
+
+function preparePostRegistrationAutoLoginTestFixture(stormpathApplication,cb){
+
+  var newAccount = helpers.newUser();
+
+  var sideEffectData = uuid.v4();
+
+  var app = helpers.createStormpathExpressApp({
+    application: stormpathApplication,
+    web:{
+      register: {
+        enabled: true,
+        autoLogin: true
+      }
+    },
+    postRegistrationHandler: function(account,req,res,next){
+      fixture.sideEffect = sideEffectData;
+      next();
+    }
+  });
+
+  var fixture = {
+    expressApp: app,
+    newAccountObject: newAccount,
+    sideEffectData: sideEffectData,
+    sideEffect: null
+  };
+
+  app.on('stormpath.ready', cb.bind(null,fixture));
+}
+
+describe('Post-Registration Handler',function() {
+  var stormpathApplication = null;
+  before(function(done) {
+
+    helpers.createApplication(helpers.createClient(), function(err, app) {
+      if (err) {
+        return done(err);
+      }
+
+      stormpathApplication = app;
+      done();
+    });
+  });
+
+  describe('with a JSON post',function(){
+
+    it('should be given the expanded account object',function(done){
+
+      preparePostRegistrationExpansionTestFixture(stormpathApplication,function(fixture){
+
+        request(fixture.expressApp)
+          .post('/register')
+          .set('Accept', 'application/json')
+          .type('json')
+          .send(fixture.newAccountObject)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            assert(res.body.customData.favoriteColor === fixture.newAccountObject.favoriteColor);
+            done();
+          });
+      });
+    });
+
+    it('should allow me to do work, then call next (let framework end the response)',function(done){
+      preparePostRegistrationPassThroughTestFixture(stormpathApplication,function(fixture){
+        request(fixture.expressApp)
+          .post('/register')
+          .set('Accept', 'application/json')
+          .type('json')
+          .send(fixture.newAccountObject)
+          .expect(200)
+          .end(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            assert(fixture.sideEffect === fixture.sideEffectData);
+            done();
+          });
+      });
+    });
+
+    it('shoud call the postRegistrationHandler, even if autoLogin is true',function(done){
+      preparePostRegistrationAutoLoginTestFixture(stormpathApplication,function(fixture){
+        request(fixture.expressApp)
+          .post('/register')
+          .set('Accept', 'application/json')
+          .type('json')
+          .send(fixture.newAccountObject)
+          .expect('Set-Cookie', /access_token=[^;]+/)
+          .expect(200)
+          .end(function(err,res) {
+            if (err) {
+              return done(err);
+            }
+
+            assert(fixture.sideEffect === fixture.sideEffectData);
+            done();
+          });
+      });
+    });
+  });
+  describe('with a Form-Encoded post',function(){
+
+    it('should be given the expanded account object',function(done){
+      preparePostRegistrationExpansionTestFixture(stormpathApplication,function(fixture){
+        request(fixture.expressApp)
+          .post('/register')
+          .send(fixture.newAccountObject)
+          .expect(200)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+            assert(res.body.customData.favoriteColor === fixture.newAccountObject.favoriteColor);
+            done();
+          });
+      });
+    });
+
+    it('should allow me to do work, then call next (let framework end the response)',function(done){
+      preparePostRegistrationPassThroughTestFixture(stormpathApplication,function(fixture){
+        request(fixture.expressApp)
+          .post('/register')
+          .send(fixture.newAccountObject)
+          .expect(302)
+          .end(function(err) {
+            if (err) {
+              return done(err);
+            }
+            assert(fixture.sideEffect === fixture.sideEffectData);
+            done();
+          });
+      });
+    });
+    it('shoud call the postRegistrationHandler, even if autoLogin is true',function(done){
+      preparePostRegistrationAutoLoginTestFixture(stormpathApplication,function(fixture){
+        request(fixture.expressApp)
+          .post('/register')
+          .send(fixture.newAccountObject)
+          .expect('Set-Cookie', /access_token=[^;]+/)
+          .expect(302)
+          .end(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            assert(fixture.sideEffect === fixture.sideEffectData);
+            done();
+          });
+      });
+    });
+  });
+});


### PR DESCRIPTION
* Fixing the `postRegistrationHandler`, it is now called even if `config.web.register.autoLogin` is `false`.  It now receives an expanded account object.
* Fixing the `postLoginHandler`, it now receives an expanded account object.
* Writing test to assert the `/me` route is expanding the custom data

Closes #114 #124 #123 