### PR TITLE
Making api-authentication-required expose apiKey into req and res

### DIFF
--- a/lib/middleware/api-authentication-required.js
+++ b/lib/middleware/api-authentication-required.js
@@ -19,8 +19,10 @@ module.exports = function(req, res, next) {
   var logger = req.app.get('stormpathLogger');
 
   // Wipe user data in case it was previously set by helpers.getUser().
+  req.apiKey = undefined;
   req.user = undefined;
   req.permissions = undefined;
+  res.locals.apiKey = undefined;
   res.locals.user = undefined;
   res.locals.permissions = undefined;
 
@@ -42,8 +44,10 @@ module.exports = function(req, res, next) {
           return res.status(401).json({ error: 'Invalid API credentials.' });
         }
 
+        res.locals.apiKey = authResult;
         res.locals.user = expandedAccount;
         res.locals.permissions = authResult.grantedScopes;
+        req.apiKey = authResult;
         req.user = expandedAccount;
         req.permissions = authResult.grantedScopes;
 


### PR DESCRIPTION
A very simple PR that makes api-authentication-required expose the successfully authenticated ApiKey into the req and res.