### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
   $ export STORMPATH_CLIENT_APIKEY_SECRET=<YOUR-SECRET-HERE>
   ```
 
-  *On Windows, use the `setx` command instead of `export`.*
+  *On Windows, use the `set` or `setx` command instead of `export`.*
 
 3. **Get Your Stormpath App HREF**
 
@@ -47,7 +47,7 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
   $ export STORMPATH_APPLICATION_HREF=<YOUR-STORMPATH-APP-HREF>
   ```
 
-  *On Windows, use the `setx` command instead of `export`.*
+  *On Windows, use the `set` or `setx` command instead of `export`.*
 
 5. **Install The SDK**
 
@@ -63,26 +63,40 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
 
 7. **Initialize It**
 
-  **If your app is an API:**
+  You need to initalize the middlware and use it with your application.  We have
+  options for various use cases.
 
-  Set `api` to `true` and point `web.spaRoot` to where your front-end app is located. This will serve your app and create default API routes for login, registration, etc.
-
-  ```javascript
-  app.use(stormpath.init(app, {
-    api: true,
-    web: {
-      spaRoot: path.join(SPA_ROOT, 'index.html')
-    }
-  }));
-  ```
-
-  **If your app is a website:**
+  **If your app is a traditional website:**
 
   Set `website` to `true`. This will setup default views for login, registration, etc.
 
   ```javascript
   app.use(stormpath.init(app, {
     website: true
+  }));
+  ```
+
+  If your app is a single page application (Angular, React), you will need to
+  tell our library where the root file is.  For example, if your Angular app is
+  in the `client/` folder in your project:
+
+  ```javascript
+  app.use(stormpath.init(app, {
+    website: true,
+    web: {
+      spaRoot: path.join(__dirname, 'client' 'index.html')
+    }
+  }));
+  ```
+
+  **If your app is an API service:**
+
+  If your application is an API service that requires the use of OAuth Bearer
+  Tokens, then enable the API option:
+
+  ```javascript
+  app.use(stormpath.init(app, {
+    api: true
   }));
   ```
 
@@ -116,9 +130,13 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
 
   To access a protected route, the user must first login.
 
-  **If your app is an API:**
+  **Traditional Websites:**
 
-  Log them in by posting their username and password as JSON to the `/login` endpoint:
+  You can login by visiting the `/login` URL and submitting the login form
+
+  **Single Page Apps:**
+
+  Your front-end client should POST this data to the `/login` endpoint:
 
   ```javascript
   {
@@ -127,11 +145,23 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
   }
   ```
 
-  If the login attempt was successful, you will receive a 200 response and a session cookie will be set on the response. If an error occurred, we will send a 400 status with an error message in the body.
+  *Note: make sure that your client is setting the `Accept: application/json`
+  header on the request.*
 
-  **If your app is a website:**
+  *Using AngularJS?  Try our [Stormpath Angular SDK][]*
 
-  Log them in by sending them to `/login` and fill in the login form.
+  **API Services**
+
+  If your app is an API service that uses our client_crential workflow, your API consumers
+  can obtain access tokens by making this POST to your server:
+
+  ```
+  POST /oauth/token
+  Authorization: Basic <Base64Endoded(ACCOUNT_API_KEY_ID:ACCOUNT_API_KEY_SECRET);
+  Content-Type: application/x-www-form-urlencoded
+
+  grant_type=client_credentials
+  ```
 
   *[Read more about login in the documentation →](https://docs.stormpath.com/nodejs/express/latest/login.html)*
 
@@ -139,9 +169,14 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
 
   To be able to login, your users first need an account.
 
-  **If your app is an API:**
+  **Traditional Websites:**
 
-  Sign them up by posting their information as JSON to the `/register` endpoint:
+  Users can register by visiting the `/register` URL and submitting the
+  registration form.
+
+  **Single Page Applications:**
+
+  Your front-end client should POST this data to the `/register` endpoint:
 
   ```javascript
   {
@@ -150,11 +185,14 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
   }
   ```
 
-  If the user was created successfully, you will receive a 200 response and the body will contain the account that was created. If an error occurred, we will send a 400 status with an error message in the body.
+  If the user was created successfully, you will receive a 200 response and the
+  body will contain the account that was created. If an error occurred, we will
+  send a 400 status with an error message in the body.
 
-  **If your app is a website:**
+  *Note: make sure that your client is setting the `Accept: application/json`
+  header on the request.*
 
-  Sign them up by sending them to `/register` and fill in the form.
+  *Using AngularJS?  Try our [Stormpath Angular SDK][]*
 
   *[Read more about registration in the documentation →](https://docs.stormpath.com/nodejs/express/latest/registration.html)*
 
@@ -184,3 +222,5 @@ Below are some resources you might find useful.
 ## License
 
 Apache 2.0, see [LICENSE](LICENSE).
+
+[Stormpath Angular SDK]: https://github.com/stormpath/stormpath-sdk-angularjs

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
 
 7. **Initialize It**
 
-  You need to initalize the middlware and use it with your application.  We have
+  You need to initialize the middlware and use it with your application.  We have
   options for various use cases.
 
   **If your app is a traditional website:**

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
   }));
   ```
 
-  *[Read more about the initialization in the documentation →](https://docs.stormpath.com/nodejs/express/latest/configuration.html#initialize-express-stormpath)*
+  *[Read more about the initialization in the documentation →][]*
 
 8. **Wait For The SDK**
 
@@ -163,7 +163,7 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
   grant_type=client_credentials
   ```
 
-  *[Read more about login in the documentation →](https://docs.stormpath.com/nodejs/express/latest/login.html)*
+  *[Read more about login in the documentation →][]*
 
 11. **Register**
 
@@ -194,19 +194,19 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
 
   *Using AngularJS?  Try our [Stormpath Angular SDK][]*
 
-  *[Read more about registration in the documentation →](https://docs.stormpath.com/nodejs/express/latest/registration.html)*
+  *[Read more about registration in the documentation →][]*
 
 12. **That's It!**
 
-  You just added user authentication to your app with Stormpath. See the [documentation](https://docs.stormpath.com/nodejs/express/) for further information on how Stormpath can be used with your Express.js app.
+  You just added user authentication to your app with Stormpath. See the [documentation][] for further information on how Stormpath can be used with your Express.js app.
 
 ## Documentation
 
-For a full documentation of this library, see the [documentation](https://docs.stormpath.com/nodejs/express/).
+For a full documentation of this library, see the [documentation][].
 
 ## Help
 
-Contact us via email at support@stormpath.com or visit our [support center](https://support.stormpath.com).
+Contact us via email at support@stormpath.com or visit our [support center][].
 
 ## Example
 
@@ -223,4 +223,9 @@ Below are some resources you might find useful.
 
 Apache 2.0, see [LICENSE](LICENSE).
 
+[documentation]: https://docs.stormpath.com/nodejs/express/
+[Read more about login in the documentation →]: https://docs.stormpath.com/nodejs/express/latest/login.html
+[Read more about registration in the documentation →]: https://docs.stormpath.com/nodejs/express/latest/registration.html
+[Read more about the initialization in the documentation →]: https://docs.stormpath.com/nodejs/express/latest/configuration.html#initialize-express-stormpath
 [Stormpath Angular SDK]: https://github.com/stormpath/stormpath-sdk-angularjs
+[support center]: https://support.stormpath.com

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
   app.use(stormpath.init(app, {
     website: true,
     web: {
-      spaRoot: path.join(__dirname, 'client' 'index.html')
+      spaRoot: path.join(__dirname, 'client', 'index.html')
     }
   }));
   ```
@@ -132,7 +132,7 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
 
   **Traditional Websites:**
 
-  You can login by visiting the `/login` URL and submitting the login form
+  You can login by visiting the `/login` URL and submitting the login form.
 
   **Single Page Apps:**
 
@@ -152,12 +152,12 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
 
   **API Services**
 
-  If your app is an API service that uses our client_crential workflow, your API consumers
+  If your app is an API service that uses our client_credentials workflow, your API consumers
   can obtain access tokens by making this POST to your server:
 
   ```
   POST /oauth/token
-  Authorization: Basic <Base64Endoded(ACCOUNT_API_KEY_ID:ACCOUNT_API_KEY_SECRET);
+  Authorization: Basic <Base64Endoded(ACCOUNT_API_KEY_ID:ACCOUNT_API_KEY_SECRET)>;
   Content-Type: application/x-www-form-urlencoded
 
   grant_type=client_credentials


### PR DESCRIPTION
The way it was written, we were telling people that single-page applications were meant to be used with the `api` option.  This is not correct, SPAs need the `website` option.  The `api` option enables or OAuth workflows, nothing else.

I still need to file a Discuss issue so that we can discuss how we feel about these option profiles.  But in the meantime I want to make these updates to the README so that we reduce confusion