### PR TITLE
Fix tests that aren’t cleaning up application resources

### DIFF
--- a/test/controllers/test-register.js
+++ b/test/controllers/test-register.js
@@ -758,52 +758,15 @@ describe('register', function() {
     });
 
     it('should return the user to the login page with ?status=unverified if the account is unverified', function(done) {
-      var application;
-      var client = helpers.createClient();
 
       async.series([
         function(callback) {
-          client.createApplication({ name: uuid.v4() }, { createDirectory: true }, function(err, app) {
-            if (err) {
-              return callback(err);
-            }
-
-            application = app;
-            callback();
-          });
-        },
-        function(callback) {
-          application.getDefaultAccountStore(function(err, mapping) {
-            if (err) {
-              return callback(err);
-            }
-
-            mapping.getAccountStore(function(err, store) {
-              if (err) {
-                return callback(err);
-              }
-
-              store.getAccountCreationPolicy(function(err, policy) {
-                if (err) {
-                  return callback(err);
-                }
-
-                policy.verificationEmailStatus = 'ENABLED';
-                policy.save(function(err) {
-                  if (err) {
-                    return callback(err);
-                  }
-
-                  callback();
-                });
-              });
-            });
-          });
+          helpers.setEmailVerificationStatus(stormpathApplication,'ENABLED',callback);
         },
         function(callback) {
           var app = helpers.createStormpathExpressApp({
             application: {
-              href: application.href
+              href: stormpathApplication.href
             },
             web: {
               register: {
@@ -837,7 +800,7 @@ describe('register', function() {
           });
         }
       ], function(err) {
-        done(err);
+        helpers.setEmailVerificationStatus(stormpathApplication,'DISABLED',done);
       });
     });
 

--- a/test/handlers/test-me.js
+++ b/test/handlers/test-me.js
@@ -48,6 +48,10 @@ describe('current user (/me) route',function() {
     });
   });
 
+  after(function(done) {
+    helpers.destroyApplication(stormpathApplication, done);
+  });
+
   it('should respond with the expanded account object',function(done){
     prepateMeTestFixture(stormpathApplication,function(fixture){
       var agent = request.agent(fixture.expressApp);

--- a/test/handlers/test-post-login-handler.js
+++ b/test/handlers/test-post-login-handler.js
@@ -70,6 +70,10 @@ describe('Post-Login Handler',function() {
     });
   });
 
+  after(function(done) {
+    helpers.destroyApplication(stormpathApplication, done);
+  });
+
   describe('with a JSON post',function(){
 
     it('should be given the expanded account object',function(done){

--- a/test/handlers/test-post-registration-handler.js
+++ b/test/handlers/test-post-registration-handler.js
@@ -102,6 +102,10 @@ describe('Post-Registration Handler',function() {
     });
   });
 
+  after(function(done) {
+    helpers.destroyApplication(stormpathApplication, done);
+  });
+
   describe('with a JSON post',function(){
 
     it('should be given the expanded account object',function(done){

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,6 +8,10 @@ var stormpathExpress = require('../');
 
 var express = require('express');
 
+var pkg = require('../package.json');
+
+var testRunId = uuid.v4().split('-')[0];
+
 /**
  * Build a new Stormpath Client for usage in tests.
  *
@@ -46,7 +50,7 @@ module.exports.newUser = function() {
  * @param {Object} application - The initialized Stormpath Application object.
  */
 module.exports.createApplication = function(client, callback) {
-  var appData = { name: uuid.v4() };
+  var appData = { name: pkg.name + ':' + testRunId + ':' + uuid.v4() };
   var opts = { createDirectory: true };
 
   client.createApplication(appData, opts, callback);

--- a/test/test-stormpath.js
+++ b/test/test-stormpath.js
@@ -23,7 +23,7 @@ describe('#init()', function() {
 
       var app = helpers.createStormpathExpressApp({ application: { href: application.href } });
       app.on('stormpath.ready', function() {
-        done();
+        helpers.destroyApplication(application, done);
       });
     });
   });
@@ -48,7 +48,7 @@ describe('#init()', function() {
 
       var app = helpers.createStormpathExpressApp({ application: { href: application.href } });
       app.on('stormpath.ready', function() {
-        done();
+        helpers.destroyApplication(application, done);
       });
     });
   });


### PR DESCRIPTION
Most of these were my fault, oopsies :)

I also added the package name and a per-process uuid to the application name, so that (a) I could see how many apps were being leftover per run and (b) so that others can know that this is our library