### PR TITLE
Make api-authentication-required expose the authenticationResult into the request/response

### DIFF
--- a/lib/middleware/api-authentication-required.js
+++ b/lib/middleware/api-authentication-required.js
@@ -19,8 +19,10 @@ module.exports = function (req, res, next) {
   var logger = req.app.get('stormpathLogger');
 
   // Wipe user data in case it was previously set by helpers.getUser().
+  req.authenticationResult = undefined;
   req.user = undefined;
   req.permissions = undefined;
+  res.locals.authenticationResult = undefined;
   res.locals.user = undefined;
   res.locals.permissions = undefined;
 
@@ -42,8 +44,10 @@ module.exports = function (req, res, next) {
           return res.status(401).json({ error: 'Invalid API credentials.' });
         }
 
+        res.locals.authenticationResult = authResult;
         res.locals.user = expandedAccount;
         res.locals.permissions = authResult.grantedScopes;
+        req.authenticationResult = authResult;
         req.user = expandedAccount;
         req.permissions = authResult.grantedScopes;
 


### PR DESCRIPTION
Originally from #148, but inability to get Travis to work with building that (probably because it's a PR from fork) I created this instead.

Closes #148, #138.