### PR TITLE
[POC - DO NOT MERGE] Prevent body-parsing on non-stormpath managed routes

### DIFF
--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -72,12 +72,15 @@ module.exports.init = function (app, opts) {
   var client = initClient(app, opts);
 
   // Parse the request body.
-  app.use(function(req,res,next) {
-    // TODO: I do not know where/what all of these are
-    var stormpathRoutes = [];
+  router.use(function(req, res, next) {
+    var exemptRoutes = ["/api/"];
 
-    if(stormpathRoutes.indexOf(req.path) > -1) {
-      router.use(bodyParser.urlencoded({ extended: true }));
+    var skipBodyParsing = exemptRoutes
+      .map(function (exemption) { return req.path.match(exemption) !== null; })
+      .reduce(function (value, memo) { return value || memo; }, false);
+
+    if (skipBodyParsing) {
+      bodyParser.urlencoded({ extended: true })(req, res, next);
     }
     else {
       return next();

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -72,7 +72,17 @@ module.exports.init = function (app, opts) {
   var client = initClient(app, opts);
 
   // Parse the request body.
-  router.use(bodyParser.urlencoded({ extended: true }));
+  app.use(function(req,res,next) {
+    // TODO: I do not know where/what all of these are
+    var stormpathRoutes = [];
+
+    if(stormpathRoutes.indexOf(req.path) > -1) {
+      router.use(bodyParser.urlencoded({ extended: true }));
+    }
+    else {
+      return next();
+    }
+  });
 
   // Indicates whether or not the client is ready.
   var isClientReady = false;

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -80,10 +80,9 @@ module.exports.init = function (app, opts) {
       .reduce(function (value, memo) { return value || memo; }, false);
 
     if (skipBodyParsing) {
-      bodyParser.urlencoded({ extended: true })(req, res, next);
-    }
-    else {
       return next();
+    } else {
+      bodyParser.urlencoded({ extended: true })(req, res, next);
     }
   });
 


### PR DESCRIPTION
After investigating a bit, it looks like there are 3 ways to solve #180 One of which will close #194 as well:

1. Rather than installing bodyParser globally, install a middleware that only applies the body parser to the routes you care about. That is what I did for this PR since it is the most minimally invasive (read: quick and dirty).
2. Just use the bodyParser as route middleware instead of global middleware. e.g. `app.get(/"login", bodyParser, myLoginHandler)`. This one is nice since it has no global middleware installed and is very explicit but the disadvantage is more boilerplate each time you write a route.
3. Remove bodyParser altogether and replace it with [body](https://www.npmjs.com/package/body) or [raw-body](https://www.npmjs.com/package/raw-body). The HUGE advantage here is that you both shrink your footprint on the integrator's app and you remove the dependence on the integrator using the specific body parser config as mentioned in #194. This will close both #180 and #194 but it will require a bit of rework in the app.

Since apps like mine that rely on [http-proxy](https://github.com/nodejitsu/node-http-proxy) or node streams for requests cannot use this lib at all unless some solution is in place I'd prefer to start with 1 or 2 since it's super quick then implement 3 if it is possible.

For this PR, I didn't know how you would want to enumerate routes so I left the array empty. If you can help me figure out how to get the route list in there (and make sure it works with query params) then you can just use this.