### PR TITLE
Supporting local YAML overrides of framework options

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -23,5 +23,8 @@ module.exports = function (config) {
   configLoader.add(new configStrategy.EnrichIntegrationFromRemoteConfigStrategy(ClientFactory));
   configLoader.add(new configStrategy.EnrichIntegrationConfigStrategy());
 
+  // Load our integration config.
+  configLoader.add(new configStrategy.LoadFileConfigStrategy(path.join(process.cwd(), '/config.yml'), false));
+
   return new stormpath.Client(configLoader);
 };


### PR DESCRIPTION
@typerandom I noticed today that it was not possible to override the default framework configuration by placing a `config.yaml` file in the root of a project which depends on `express-stormpath`

This fixes the problem, but do you think this is the right way to do it?  The underlying `stormpath.configParser` *is* looking for the file in question, but I think it framework options get overriden when `epxress-stormpath` applies it's default configuration file.  Thus needing to re-apply the custom file, as you see in this commit.