### PR TITLE
guards against undefined 'application'

### DIFF
--- a/lib/helpers/get-user.js
+++ b/lib/helpers/get-user.js
@@ -66,6 +66,9 @@ module.exports = function (req, res, next) {
   } else if (req.cookies && req.cookies.access_token) {
     var authenticator = new stormpath.JwtAuthenticator(application);
 
+    if (!authenticator.application) {
+      return next();
+    }
     authenticator.authenticate(req.cookies.access_token, function (err, authenticationResult) {
       if (err) {
         logger.info('Failed to authenticate the request. Invalid access_token found.');
@@ -183,6 +186,9 @@ module.exports = function (req, res, next) {
       });
     });
   } else {
+    if (!application) {
+      return next();
+    }
     application.authenticateApiRequest({ request: req }, function (err, result) {
       if (err) {
         logger.info('Failed to authenticate the incoming request.');


### PR DESCRIPTION
Added guards against undefined "application". An undefined application occurs when node is restarted and the express-stormpath middleware is serving an API endpoint. I don't know why exactly "application" would be undefined, but the guards seem reasonable whatever the assumptions in this code may be. I include the stack traces that prompted my making these changes.

```
Cannot read property 'dataStore' of undefined
TypeError: Cannot read property 'dataStore' of undefined
    at JwtAuthenticator.authenticate (/home/ubuntu/nventi/node_modules/express-stormpath/node_modules/stormpath/lib/jwt/jwt-authenticator.js:38:32)
    at Object.module.exports [as getUser] (/home/ubuntu/nventi/node_modules/express-stormpath/lib/helpers/get-user.js:69:19)
    at stormpathMiddleware (/home/ubuntu/nventi/node_modules/express-stormpath/lib/stormpath.js:92:13)
    at Layer.handle [as handle_request] (/home/ubuntu/nventi/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/ubuntu/nventi/node_modules/express/lib/router/index.js:312:13)
    at /home/ubuntu/nventi/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/home/ubuntu/nventi/node_modules/express/lib/router/index.js:330:12)
    at next (/home/ubuntu/nventi/node_modules/express/lib/router/index.js:271:10)
    at /home/ubuntu/nventi/node_modules/express/lib/router/index.js:618:15
    at next (/home/ubuntu/nventi/node_modules/express/lib/router/index.js:256:14)
```

AND

```
Cannot read property 'authenticateApiRequest' of undefined
TypeError: Cannot read property 'authenticateApiRequest' of undefined
    at Object.module.exports [as getUser] (/Users/kai/nventi/server/node_modules/express-stormpath/lib/helpers/get-user.js:186:16)
    at stormpathMiddleware (/Users/kai/nventi/server/node_modules/express-stormpath/lib/stormpath.js:92:13)
    at Layer.handle [as handle_request] (/Users/kai/nventi/server/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/kai/nventi/server/node_modules/express/lib/router/index.js:312:13)
    at /Users/kai/nventi/server/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/Users/kai/nventi/server/node_modules/express/lib/router/index.js:330:12)
    at next (/Users/kai/nventi/server/node_modules/express/lib/router/index.js:271:10)
    at /Users/kai/nventi/server/node_modules/express/lib/router/index.js:618:15
    at next (/Users/kai/nventi/server/node_modules/express/lib/router/index.js:256:14)
    at cookieParser (/Users/kai/nventi/server/node_modules/cookie-parser/index.js:25:29)
```
