### PR TITLE
Fix rendering of errors during Facebook login attempt

### DIFF
--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -46,7 +46,7 @@ module.exports = function (req, res) {
   application.getAccount(userData, function (err, resp) {
     if (err) {
       logger.info('During a Facebook OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
-      return helpers.render(req, res, req.app.get('stormpathFacebookLoginFailedView'));
+      return res.status(err.status || 400).json(err);
     }
 
     res.locals.user = resp.account;


### PR DESCRIPTION
We want to send the error message directly to the browser, we don’t have a specific error view for this case (that was from the 1.x version)