### PR TITLE
add aupport for calling postReg and postLogin handlers (if defined) to facebok-login.js

### DIFF
--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -51,22 +51,29 @@ module.exports = function (req, res) {
       return helpers.render(req, res, req.app.get('stormpathFacebookLoginFailedView'));
     }
 
-    res.locals.user = resp.account;
-    req.user = resp.account;
-    helpers.createIdSiteSession(req.user, req, res);
+    helpers.expandAccount(req.app, resp.account, function (err, expandedAccount) {
+      if (err) {
+          logger.info('During a Facebook OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
+          return res.status(err.status || 400).json(err);
+      }
 
-    var nextUrl = req.query.next || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+      res.locals.user = expandedAccount;
+      req.user = expandedAccount;
+      helpers.createIdSiteSession(req.user, req, res);
 
-    if (resp.created && registrationHandler) {
-      registrationHandler(req.user, req, res, function () {
+      var nextUrl = req.query.next || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+
+      if (resp.created && registrationHandler) {
+          registrationHandler(req.user, req, res, function () {
+              res.redirect(302, nextUrl);
+          });
+      } else if (loginHandler) {
+          loginHandler(req.user, req, res, function () {
+              res.redirect(302, nextUrl);
+          });
+      } else {
           res.redirect(302, nextUrl);
-      });
-    } else if (loginHandler) {
-      loginHandler(req.user, req, res, function () {
-          res.redirect(302, nextUrl);
-      });
-    } else {
-      res.redirect(302, nextUrl);
-    }
+      }
+    });
   });
 };

--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -30,6 +30,8 @@ module.exports = function (req, res) {
   var application = req.app.get('stormpathApplication');
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
+  var loginHandler = config.postLoginHandler;
+  var registrationHandler = config.postRegistrationHandler;
 
   if (!req.query.access_token) {
     logger.info('A user attempted to log in via Facebook OAuth without specifying an OAuth token.');
@@ -53,7 +55,16 @@ module.exports = function (req, res) {
     req.user = resp.account;
     helpers.createIdSiteSession(req.user, req, res);
 
-    var url = req.query.next || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
-    res.redirect(302, url);
+    if (resp.created && registrationHandler) {
+      registrationHandler(req.user, req, res, function () {
+          res.redirect(302, nextUrl);
+      });
+    } else if (loginHandler) {
+      loginHandler(req.user, req, res, function () {
+          res.redirect(302, nextUrl);
+      });
+    } else {
+      res.redirect(302, nextUrl);
+    }
   });
 };

--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -55,6 +55,8 @@ module.exports = function (req, res) {
     req.user = resp.account;
     helpers.createIdSiteSession(req.user, req, res);
 
+    var nextUrl = req.query.next || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+
     if (resp.created && registrationHandler) {
       registrationHandler(req.user, req, res, function () {
           res.redirect(302, nextUrl);

--- a/lib/controllers/google-login.js
+++ b/lib/controllers/google-login.js
@@ -47,22 +47,29 @@ module.exports = function (req, res) {
       return res.status(err.status || 400).json(err);
     }
 
-    res.locals.user = resp.account;
-    req.user = resp.account;
-    helpers.createIdSiteSession(req.user, req, res);
+    helpers.expandAccount(req.app, resp.account, function (err, expandedAccount) {
+        if (err) {
+            logger.info('During a Google OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
+            return res.status(err.status || 400).json(err);
+        }
 
-    var nextUrl = req.query.next || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+        res.locals.user = expandedAccount;
+        req.user = expandedAccount;
+        helpers.createIdSiteSession(req.user, req, res);
 
-    if (resp.created && registrationHandler) {
-      registrationHandler(req.user, req, res, function () {
-        res.redirect(302, nextUrl);
-      });
-    } else if (loginHandler) {
-      loginHandler(req.user, req, res, function () {
-        res.redirect(302, nextUrl);
-      });
-    } else {
-      res.redirect(302, nextUrl);
-    }
+        var nextUrl = req.query.next || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+
+        if (resp.created && registrationHandler) {
+            registrationHandler(req.user, req, res, function () {
+                res.redirect(302, nextUrl);
+            });
+        } else if (loginHandler) {
+            loginHandler(req.user, req, res, function () {
+                res.redirect(302, nextUrl);
+            });
+        } else {
+            res.redirect(302, nextUrl);
+        }
+    });
   });
 };


### PR DESCRIPTION
I noticed that the facebook-login,js controller did not call the postRegistrationHandler or the postLoginHandler after validating the FB token.  I copied the appropriate code from google-login.js and added it into facebook-login.js