### PR TITLE
Fix: secure cookie properties

### DIFF
--- a/lib/helpers/create-session.js
+++ b/lib/helpers/create-session.js
@@ -14,6 +14,7 @@ module.exports = function (passwordGrantAuthenticationResult, account, req, res)
   var accessTokenCookieConfig = req.app.get('stormpathConfig').web.accessTokenCookie;
   var refreshTokenCookieConfig = req.app.get('stormpathConfig').web.refreshTokenCookie;
   var cookies = new Cookies(req, res);
+  var isSecureRequest = (req.protocol === 'https');
 
   res.locals.user = account;
   req.user = account;
@@ -23,7 +24,7 @@ module.exports = function (passwordGrantAuthenticationResult, account, req, res)
     expires: new Date(passwordGrantAuthenticationResult.accessToken.body.exp * 1000),
     httpOnly: accessTokenCookieConfig.httpOnly,
     path: accessTokenCookieConfig.path,
-    secure: (accessTokenCookieConfig.https !== null ? accessTokenCookieConfig.https : (req.protocol === 'https'))
+    secure: (accessTokenCookieConfig.secure === null ? isSecureRequest : accessTokenCookieConfig.secure)
   });
 
   cookies.set(refreshTokenCookieConfig.name, passwordGrantAuthenticationResult.refreshToken, {
@@ -31,6 +32,6 @@ module.exports = function (passwordGrantAuthenticationResult, account, req, res)
     expires: new Date(passwordGrantAuthenticationResult.refreshToken.body.exp * 1000),
     httpOnly: refreshTokenCookieConfig.httpOnly,
     path: refreshTokenCookieConfig.path,
-    secure: (refreshTokenCookieConfig.https !== null ? refreshTokenCookieConfig.https : (req.protocol === 'https'))
+    secure: (refreshTokenCookieConfig.secure === null ? isSecureRequest : refreshTokenCookieConfig.secure)
   });
 };


### PR DESCRIPTION
The reference to `https` was undefined, which meant that we would pass undefined for the secure value (which meant that the secure value was never set to true).  This PR fixes that.