### PR TITLE
Use field label when rendering field validation errors

### DIFF
--- a/lib/helpers/get-required-registration-fields.js
+++ b/lib/helpers/get-required-registration-fields.js
@@ -25,7 +25,7 @@ module.exports = function (config, callback) {
 
   async.forEachOf(config.web.register.fields || {}, function (field, fieldName, cb) {
     if (field && field.enabled && field.required) {
-      fields.push(field.name);
+      fields.push(field);
     }
 
     cb();

--- a/lib/helpers/validate-account.js
+++ b/lib/helpers/validate-account.js
@@ -26,8 +26,8 @@ module.exports = function (formData, stormpathConfig, callback) {
 
   getRequiredRegistrationFields(stormpathConfig, function (requiredFields) {
     async.each(requiredFields, function (field, cb) {
-      if (accountFieldNames.indexOf(field) <= -1 || (accountFieldNames.indexOf(field) > -1 && !formData[field])) {
-        errors.push(new Error(field + ' required.'));
+      if (accountFieldNames.indexOf(field.name) <= -1 || (accountFieldNames.indexOf(field.name) > -1 && !formData[field.name])) {
+        errors.push(new Error((field.label || field.name) + ' required.'));
       }
 
       cb();

--- a/test/controllers/test-register.js
+++ b/test/controllers/test-register.js
@@ -408,7 +408,7 @@ describe('register', function () {
               return done(err);
             }
 
-            assert.equal(res.body.error, 'givenName required.');
+            assert.equal(res.body.error, 'First Name required.');
 
             done();
           });
@@ -606,7 +606,7 @@ describe('register', function () {
 
             var $ = cheerio.load(res.text);
             assert($('.alert.alert-danger p').length);
-            assert.notEqual($('.alert.alert-danger p').text().indexOf('givenName'), -1);
+            assert.notEqual($('.alert.alert-danger p').text().indexOf('First Name'), -1);
 
             done();
           });


### PR DESCRIPTION
This is more user-friendly than "givenName", etc.

To verify:

Use our [sample project](https://github.com/stormpath/express-stormpath-sample-project) and visit the registration form.  Use your web inspector to remove the `required` attribute from the "First Name" field, so that HTML form validation does not prevent you from submitting the form.  Submit the form and you should see the error "First Name required"

This should go in a minor release, and the upgrade log should note that the error messages are changing (as some may be depending on the errors, particularly if using the JSON responses)