### PR TITLE
Fix: Change config load order

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -21,8 +21,8 @@ module.exports = function (config) {
   // Load our integration config.
   configLoader.prepend(new configStrategy.LoadFileConfigStrategy(path.join(__dirname, '/config.yml'), true));
   configLoader.add(new configStrategy.EnrichClientFromRemoteConfigStrategy(ClientFactory));
-  configLoader.add(new configStrategy.EnrichIntegrationFromRemoteConfigStrategy(ClientFactory));
   configLoader.add(new configStrategy.EnrichIntegrationConfigStrategy());
+  configLoader.add(new configStrategy.EnrichIntegrationFromRemoteConfigStrategy(ClientFactory));
 
   return new stormpath.Client(configLoader);
 };


### PR DESCRIPTION
Fix issue with `EnrichIntegrationFromRemoteConfigStrategy` being run before `EnrichIntegrationConfigStrategy `. This resulted in `EnrichIntegrationFromRemoteConfigStrategy` not being able to pick up some flags that were being set by `EnrichIntegrationConfigStrategy` at runtime.