### PR TITLE
Fix: Load express version from application modules

### DIFF
--- a/lib/helpers/get-app-module-version.js
+++ b/lib/helpers/get-app-module-version.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+var cachedModulePaths = {};
+var globalModulesPath = process.env.NODE_PATH;
+var appFilePath = require.main.filename;
+var appModulesPath = path.join(path.dirname(fs.realpathSync(appFilePath)), 'node_modules');
+
+function getApplicationModulePath(name) {
+  if (name in cachedModulePaths) {
+    return cachedModulePaths[name];
+  }
+
+  var result = false;
+
+  var modulePaths = [
+    path.join(appModulesPath, name)
+  ];
+
+  if (globalModulesPath) {
+    modulePaths.push(path.join(globalModulesPath, name));
+  }
+
+  while (modulePaths.length) {
+    var modulePath = modulePaths.shift();
+    if (fs.existsSync(modulePath)) {
+      result = modulePath;
+      break;
+    }
+  }
+
+  cachedModulePaths[name] = result;
+
+  return result;
+}
+
+/**
+ * Gets the version of a module loaded at application level (process).
+ *
+ * @method
+ * @private
+ *
+ * @param {string} name - Name of the module that you want to resolve the version for.
+ *
+ * @return {string} Module version, or false if the module couldn't be found.
+ */
+module.exports = function getApplicationModuleVersion(name) {
+  var modulePath = getApplicationModulePath(name);
+
+  if (modulePath) {
+    var loadedModule = require(path.join(modulePath, 'package.json'));
+    if (loadedModule) {
+      return loadedModule.version;
+    }
+  }
+
+  return false;
+};

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -8,6 +8,7 @@ module.exports = {
   getFormModel: require('./get-form-model'),
   getRequiredRegistrationFields: require('./get-required-registration-fields'),
   getUser: require('./get-user'),
+  getAppModuleVersion: require('./get-app-module-version'),
   loginResponder: require('./login-responder'),
   prepAccountData: require('./prep-account-data'),
   render: require('./render'),

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -2,7 +2,6 @@
 
 var cookieParser = require('cookie-parser');
 var express = require('express');
-var expressVersion = require('express/package.json').version;
 var winston = require('winston');
 
 var controllers = require('./controllers');
@@ -10,6 +9,8 @@ var helpers = require('./helpers');
 var middleware = require('./middleware');
 var version = require('../package.json').version;
 var bodyParser = helpers.bodyParser;
+
+var expressVersion = helpers.getAppModuleVersion('express') || 'unknown';
 
 /**
  * Initialize the Stormpath client.


### PR DESCRIPTION
Currently the Express version that we report in our user agent is the one that we have loaded in our package (`express-stormpath`). I.e. it might not be the same that the user is actually using.

Therefore I suggest this fix, so that we resolve the package ourselves by first looking in the path of the running process and its node_modules directory, then if that doesn't exist we fall back to the global node_modules directory.

If we are able to find a module in either one of those directories, then we simply load the package.json file from there and get the version.

Fixes #239