### PR TITLE
Refactor: Rename serveAngular as addSpaRoute

### DIFF
--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -113,7 +113,7 @@ module.exports.init = function (app, opts) {
       next();
     }
 
-    function serveAngular(path) {
+    function addSpaRoute(path) {
       router.get(path, function (req, res) {
         res.sendFile(web.spaRoot);
       });
@@ -133,7 +133,7 @@ module.exports.init = function (app, opts) {
         router.get(web.register.uri, controllers.idSiteRedirect({ path: web.idSite.registerUri }));
       } else {
         if (web.spaRoot) {
-          serveAngular(web.register.uri);
+          addSpaRoute(web.register.uri);
         } else {
           router.get(web.register.uri, controllers.register);
         }
@@ -147,7 +147,7 @@ module.exports.init = function (app, opts) {
       } else {
         router.use(web.login.uri, stormpathMiddleware);
         if (web.spaRoot) {
-          serveAngular(web.login.uri);
+          addSpaRoute(web.login.uri);
         } else {
           router.get(web.login.uri, controllers.login);
         }
@@ -182,7 +182,7 @@ module.exports.init = function (app, opts) {
 
     if (web.changePassword.enabled) {
       if (web.spaRoot) {
-        serveAngular(web.changePassword.uri);
+        addSpaRoute(web.changePassword.uri);
       } else {
         router.get(web.changePassword.uri, controllers.changePassword);
       }


### PR DESCRIPTION
Small internal refactor. Simply make the use of `serveAngular()` clearer by renaming it to `addSpaRoute()`.