### PR TITLE
Fix: Body parser middleware issues

### DIFF
--- a/lib/helpers/body-parser.js
+++ b/lib/helpers/body-parser.js
@@ -18,6 +18,11 @@ function handleBodyFn(options, bodyFn) {
   options.limit = bytes.parse(options.limit || defaultSizeLimit);
 
   return function (req, res, next) {
+    // If the body is already parsed, by e.g. body-parser, then skip parsing.
+    if (req.body !== undefined) {
+      return next();
+    }
+
     bodyFn(req, res, options, function (err, parsedBody) {
       req.body = parsedBody || req.body || {};
       next();

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -116,40 +116,47 @@ module.exports.init = function (app, opts) {
       });
     }
 
+    function addGetRoute(path, controller) {
+      router.get(path, bodyParser.forceDefaultBody(), controller);
+    }
+
+    function addPostRoute(path, controller, options) {
+      router.post(path, bodyParser.formOrJson(options), controller);
+    }
+
     router.use(localsMiddleware);
     router.use(cookieParser());
-    router.use(bodyParser.forceDefaultBody());
 
-    router.get('/spa-config', controllers.socialProviders);
+    addGetRoute('/spa-config', controllers.socialProviders);
 
     if (web.idSite.enabled) {
-      router.get(web.idSite.uri, controllers.idSiteVerify);
+      addGetRoute(web.idSite.uri, controllers.idSiteVerify);
     }
 
     if (web.register.enabled) {
       if (web.idSite.enabled) {
-        router.get(web.register.uri, controllers.idSiteRedirect({ path: web.idSite.registerUri }));
+        addGetRoute(web.register.uri, controllers.idSiteRedirect({ path: web.idSite.registerUri }));
       } else {
         if (web.spaRoot) {
           addSpaRoute(web.register.uri);
         } else {
-          router.get(web.register.uri, controllers.register);
+          addGetRoute(web.register.uri, controllers.register);
         }
-        router.post(web.register.uri, bodyParser.formOrJson({ limit: '11mb' }), controllers.register);
+        addPostRoute(web.register.uri, controllers.register, { limit: '11mb' });
       }
     }
 
     if (web.login.enabled) {
       if (web.idSite.enabled) {
-        router.get(web.login.uri, controllers.idSiteRedirect({ path: web.idSite.loginUri }));
+        addGetRoute(web.login.uri, controllers.idSiteRedirect({ path: web.idSite.loginUri }));
       } else {
         router.use(web.login.uri, stormpathMiddleware);
         if (web.spaRoot) {
           addSpaRoute(web.login.uri);
         } else {
-          router.get(web.login.uri, controllers.login);
+          addGetRoute(web.login.uri, controllers.login);
         }
-        router.post(web.login.uri, bodyParser.formOrJson(), controllers.login);
+        addPostRoute(web.login.uri, controllers.login);
       }
     }
 
@@ -160,21 +167,21 @@ module.exports.init = function (app, opts) {
       if (provider.enabled) {
         var controllerName = providerName + 'Login';
         if (controllerName in controllers) {
-          router.get(provider.callbackUri, controllers[controllerName]);
+          addGetRoute(provider.callbackUri, controllers[controllerName]);
         }
       }
     }
 
     if (web.logout.enabled) {
-      router.get(web.logout.uri, controllers.logout);
+      addGetRoute(web.logout.uri, controllers.logout);
     }
 
     if (web.forgotPassword.enabled) {
       if (web.idSite.enabled) {
-        router.get(web.forgotPassword.uri, controllers.idSiteRedirect({ path: web.idSite.forgotUri }));
+        addGetRoute(web.forgotPassword.uri, controllers.idSiteRedirect({ path: web.idSite.forgotUri }));
       } else {
-        router.get(web.forgotPassword.uri, controllers.forgotPassword);
-        router.post(web.forgotPassword.uri, bodyParser.formOrJson(), controllers.forgotPassword);
+        addGetRoute(web.forgotPassword.uri, controllers.forgotPassword);
+        addPostRoute(web.forgotPassword.uri, controllers.forgotPassword);
       }
     }
 
@@ -182,15 +189,15 @@ module.exports.init = function (app, opts) {
       if (web.spaRoot) {
         addSpaRoute(web.changePassword.uri);
       } else {
-        router.get(web.changePassword.uri, controllers.changePassword);
+        addGetRoute(web.changePassword.uri, controllers.changePassword);
       }
 
-      router.post(web.changePassword.uri, bodyParser.formOrJson(), controllers.changePassword);
+      addPostRoute(web.changePassword.uri, controllers.changePassword);
     }
 
     if (web.verifyEmail.enabled) {
-      router.get(web.verifyEmail.uri, controllers.verifyEmail);
-      router.post(web.verifyEmail.uri, bodyParser.formOrJson(), controllers.verifyEmail);
+      addGetRoute(web.verifyEmail.uri, controllers.verifyEmail);
+      addPostRoute(web.verifyEmail.uri, controllers.verifyEmail);
     }
 
     if (web.spaRoot || web.me.enabled) {


### PR DESCRIPTION
Fixes the default body parser object issue (#264) by only forcing a default body on requests that we serve and fixes the body parser hang issue (#276) by only parsing the body when it hasn't already been parsed.

#### How to verify

##### Default body parser (fix #264)

1. Checkout this branch (`fix-body-parser-middleware`).
2. Execute `$ npm link` so that we can link to it.
3. Create a new directory and configure a new Node.js server according to [this gist](https://gist.github.com/typerandom/11d2d428e5565ef7a57d).
4. Execute `$ npm link stormpath-express` so that we're linking to our `fix-body-parser-middleware` branch.
5. Start the server.
6. Navigate to [http://localhost:3000/register](http://localhost:3000/register).
7. Create a new account.
8. Navigate to [http://localhost:3000/forgot](http://localhost:3000/forgot).
9. Request a new password.
10. Navigate to [http://localhost:3000/login](http://localhost:3000/login).
11. Login with the credentials you provided in step 7.
12. Navigate to [http://localhost:3000/logout](http://localhost:3000/logout).
13. Check the console for errors.
14. If no errors in console and steps 6 to 9 went smooth, then \o/.

##### Body parser hanging (fix #289)

1. Create a new directory and configure a new Node.js server according to [this gist](https://gist.github.com/typerandom/b1178002a81751b82923).
2. Execute `$ npm link stormpath-express` so that we're linking to our `fix-body-parser-middleware` branch.
3. Start the server.
4. Navigate to [http://localhost:3000/register](http://localhost:3000/register).
5. Create a new account.
6. Page is redirected to [/login?status=verified](http://localhost:3000/login?status=verified). If you have email verification turned on, then it should redirect to [/login?status=unverified](http://localhost:3000/login?status=unverified).
7. Open up your server and remove the `app.use(bodyParser.urlencoded({ extended: true }));` line.
8. Repeat steps 3-6.

Fixes #264, #289