### PR TITLE
Fix: Body parser hanging issue (#289)

### DIFF
--- a/lib/helpers/body-parser.js
+++ b/lib/helpers/body-parser.js
@@ -18,6 +18,11 @@ function handleBodyFn(options, bodyFn) {
   options.limit = bytes.parse(options.limit || defaultSizeLimit);
 
   return function (req, res, next) {
+    // If the body is already parsed, by e.g. body-parser, then skip parsing.
+    if (typeof req.body === 'object') {
+      return next();
+    }
+
     bodyFn(req, res, options, function (err, parsedBody) {
       req.body = parsedBody || req.body || {};
       next();


### PR DESCRIPTION
Fixes so that if the body is already parsed by e.g. the `body-parser` module, then it isn't parsed again.

#### How to verify

1. Create a new server using this gist.
2. Start the server.
3. Navigate to /register.
4. Sign up for a new account.
5. Page is redirected to /login?status=verified. If you have email verification turned on, then it should redirect to /login?status=unverified.
6. Open up your server and remove the `app.use(bodyParser.urlencoded({ extended: true }));` line.
7. Repeat steps 3-5.

Fixes #289 