### PR TITLE
Make sure that OAuth callback errors gets handled

### DIFF
--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -38,7 +38,7 @@ module.exports = function (req, res) {
 
   if (!req.query.access_token) {
     logger.info('A user attempted to log in via Facebook OAuth without specifying an OAuth token.');
-    return oauth.errorResponder(req, res, { message: 'access_token parameter required.' });
+    return oauth.errorResponder(req, res, new Error('access_token parameter required.'));
   }
 
   var userData = {

--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -1,7 +1,9 @@
 'use strict';
 
-var helpers = require('../helpers');
 var url = require('url');
+
+var helpers = require('../helpers');
+var oauth = require('../oauth');
 
 /**
  * This controller logs in an existing user with Facebook OAuth.
@@ -36,7 +38,7 @@ module.exports = function (req, res) {
 
   if (!req.query.access_token) {
     logger.info('A user attempted to log in via Facebook OAuth without specifying an OAuth token.');
-    return res.status(400).json({ message: 'access_token parameter required.' });
+    return oauth.errorResponder(req, res, { message: 'access_token parameter required.' });
   }
 
   var userData = {
@@ -49,13 +51,13 @@ module.exports = function (req, res) {
   application.getAccount(userData, function (err, resp) {
     if (err) {
       logger.info('During a Facebook OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
-      return res.status(err.status || 400).json(err);
+      return oauth.errorResponder(req, res, err);
     }
 
     helpers.expandAccount(req.app, resp.account, function (err, expandedAccount) {
       if (err) {
         logger.info('During a Facebook OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
-        return res.status(err.status || 400).json(err);
+        return oauth.errorResponder(req, res, err);
       }
 
       res.locals.user = expandedAccount;
@@ -64,7 +66,7 @@ module.exports = function (req, res) {
       helpers.createStormpathSession(req.user, req, res, function (err) {
         if (err) {
           logger.info('During a Facebook OAuth login attempt, we were unable to create a Stormpath session.');
-          return res.status(err.status || 400).json(err);
+          return oauth.errorResponder(req, res, err);
         }
 
         var nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);

--- a/lib/controllers/google-login.js
+++ b/lib/controllers/google-login.js
@@ -1,7 +1,9 @@
 'use strict';
 
-var helpers = require('../helpers');
 var url = require('url');
+
+var helpers = require('../helpers');
+var oauth = require('../oauth');
 
 /**
  * This controller logs in an existing user with Google OAuth.
@@ -31,7 +33,7 @@ module.exports = function (req, res) {
 
   if (!req.query.code) {
     logger.info('A user attempted to log in via Google OAuth without specifying an OAuth token.');
-    return res.status(400).json({ message: 'code parameter required.' });
+    return oauth.errorResponder(req, res, { message: 'code parameter required.' });
   }
 
   var userData = {
@@ -44,13 +46,13 @@ module.exports = function (req, res) {
   application.getAccount(userData, function (err, resp) {
     if (err) {
       logger.info('During a Google OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
-      return res.status(err.status || 400).json(err);
+      return oauth.errorResponder(req, res, err);
     }
 
     helpers.expandAccount(req.app, resp.account, function (err, expandedAccount) {
       if (err) {
         logger.info('During a Google OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
-        return res.status(err.status || 400).json(err);
+        return oauth.errorResponder(req, res, err);
       }
 
       res.locals.user = expandedAccount;
@@ -59,7 +61,7 @@ module.exports = function (req, res) {
       helpers.createStormpathSession(req.user, req, res, function (err) {
         if (err) {
           logger.info('During a Google OAuth login attempt, we were unable to create a Stormpath session.');
-          return res.status(err.status || 400).json(err);
+          return oauth.errorResponder(req, res, err);
         }
 
         var nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);

--- a/lib/controllers/google-login.js
+++ b/lib/controllers/google-login.js
@@ -33,7 +33,7 @@ module.exports = function (req, res) {
 
   if (!req.query.code) {
     logger.info('A user attempted to log in via Google OAuth without specifying an OAuth token.');
-    return oauth.errorResponder(req, res, { message: 'code parameter required.' });
+    return oauth.errorResponder(req, res, new Error('code parameter required.'));
   }
 
   var userData = {

--- a/lib/controllers/linkedin-login.js
+++ b/lib/controllers/linkedin-login.js
@@ -1,8 +1,9 @@
 'use strict';
 
+var url = require('url');
+
 var helpers = require('../helpers');
 var oauth = require('../oauth');
-var url = require('url');
 
 /**
  * This controller logs in an existing user with LinkedIn OAuth.
@@ -32,12 +33,12 @@ module.exports = function (req, res) {
 
   if (!req.query.code) {
     logger.info('A user attempted to log in via LinkedIn OAuth without specifying an OAuth token.');
-    return res.status(400).json({ message: 'code parameter required.' });
+    return oauth.errorResponder(req, res, { message: 'code parameter required.' });
   }
 
   if (!oauth.common.consumeStateToken(req, res)) {
     logger.info('A user attempted to log in via LinkedIn OAuth with an invalid state token.');
-    return res.status(400).json({ message: 'Invalid state token provided.' });
+    return oauth.errorResponder(req, res, { message: 'Invalid state token provided.' });
   }
 
   oauth.linkedIn.exchangeAuthCodeForAccessToken(req, config, function (err, accessToken) {
@@ -51,7 +52,7 @@ module.exports = function (req, res) {
     application.getAccount(userData, function (err, resp) {
       if (err) {
         logger.info('During a LinkedIn OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
-        return res.status(err.status || 400).json(err);
+        return oauth.errorResponder(req, res, err);
       }
 
       res.locals.user = resp.account;
@@ -60,7 +61,7 @@ module.exports = function (req, res) {
       helpers.createStormpathSession(req.user, req, res, function (err) {
         if (err) {
           logger.info('During a LinkedIn OAuth login attempt, we were unable to create a Stormpath session.');
-          return res.status(err.status || 400).json(err);
+          return oauth.errorResponder(req, res, err);
         }
 
         var nextUrl = oauth.common.consumeRedirectUri(req, res);

--- a/lib/controllers/linkedin-login.js
+++ b/lib/controllers/linkedin-login.js
@@ -33,12 +33,12 @@ module.exports = function (req, res) {
 
   if (!req.query.code) {
     logger.info('A user attempted to log in via LinkedIn OAuth without specifying an OAuth token.');
-    return oauth.errorResponder(req, res, { message: 'code parameter required.' });
+    return oauth.errorResponder(req, res, new Error('code parameter required.'));
   }
 
   if (!oauth.common.consumeStateToken(req, res)) {
     logger.info('A user attempted to log in via LinkedIn OAuth with an invalid state token.');
-    return oauth.errorResponder(req, res, { message: 'Invalid state token provided.' });
+    return oauth.errorResponder(req, res, new Error('Invalid state token provided.'));
   }
 
   oauth.linkedIn.exchangeAuthCodeForAccessToken(req, config, function (err, accessToken) {

--- a/lib/helpers/login-with-oauth-provider.js
+++ b/lib/helpers/login-with-oauth-provider.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var loginResponder = require('./login-responder');
 var exchangeStormpathToken = require('./exchange-stormpath-token');
+var loginResponder = require('./login-responder');
+var oauth = require('../oauth');
 
 /**
  * loginWithOAuthProvider takes provider data, such as an access token,
@@ -18,7 +19,7 @@ module.exports = function loginWithOAuthProvider(options, req, res) {
 
   application.getAccount(options, function (err, providerAccountResult) {
     if (err) {
-      return res.status(400).json({ error: err.userMessage || err.message });
+      return oauth.errorResponder(req, res, err);
     }
 
     var account = providerAccountResult.account;

--- a/lib/oauth/error-responder.js
+++ b/lib/oauth/error-responder.js
@@ -1,0 +1,62 @@
+'use strict';
+
+var _ = require('lodash');
+var url = require('url');
+
+var helpers = require('../helpers');
+var forms = require('../forms');
+var resolveStateToken = require('./common').resolveStateToken;
+
+/**
+ * oauthErrorResponder takes an error object and respondes
+ * either by rendering the login form with the error, or
+ * by returning the error as JSON.
+ *
+ * @method
+ *
+ * @param {Object} req - The http request.
+ * @param {Object} res - The http response.
+ * @param {Object} err - The error to handle.
+ */
+function oauthErrorResponder(req, res, err) {
+  var accepts = req.accepts(['html', 'json']);
+  var config = req.app.get('stormpathConfig');
+
+  function renderLoginFormWithError(err) {
+    var view = req.app.get('stormpathConfig').web.login.view;
+    var nextUri = url.parse(req.query.next || '').path;
+    var formActionUri = config.web.login.uri + (nextUri ? ('?next=' + nextUri) : '');
+    var oauthStateToken = resolveStateToken(req, res);
+
+    var hasSocialProviders = _.some(config.socialProviders, function (socialProvider) {
+      return socialProvider.enabled;
+    });
+
+    if (err.code === 7201) {
+      // Stormpath is unable to create or update the account because the
+      // Facebook or Google response did not contain the required property.
+      err.userMessage = 'We were unable to log you in because we couldn\'t find your email address. Please make sure you give us access to read your email address.';
+    }
+
+    var options = {
+      form: forms.loginForm,
+      formActionUri: formActionUri,
+      oauthStateToken: oauthStateToken,
+      hasSocialProviders: hasSocialProviders,
+      error: err.userMessage || err.message
+    };
+
+    helpers.render(req, res, view, options);
+  }
+
+  switch (accepts) {
+    case 'json':
+      return res.status(err.status || 400).json(err);
+
+    case 'html':
+    default:
+      return renderLoginFormWithError(err);
+  }
+}
+
+module.exports = oauthErrorResponder;

--- a/lib/oauth/error-responder.js
+++ b/lib/oauth/error-responder.js
@@ -8,6 +8,45 @@ var forms = require('../forms');
 var common = require('./common');
 
 /**
+ * Takes an error object and renders the login
+ * form with that error.
+ *
+ * @method
+ *
+ * @param {Object} req - The http request.
+ * @param {Object} res - The http response.
+ * @param {Object} config - Stormpath config.
+ * @param {Object} err - The error to display.
+ */
+function renderLoginFormWithError(req, res, config, err) {
+  var view = config.web.login.view;
+  var nextUri = url.parse(req.query.next || '').path;
+  var encodedNextUri = encodeURIComponent(nextUri);
+  var formActionUri = config.web.login.uri + (nextUri ? ('?next=' + encodedNextUri) : '');
+  var oauthStateToken = common.resolveStateToken(req, res);
+
+  var hasSocialProviders = _.some(config.socialProviders, function (socialProvider) {
+    return socialProvider.enabled;
+  });
+
+  // Stormpath is unable to create or update the account because the
+  // Facebook or Google response did not contain the required property.
+  if (err.code === 7201) {
+    err.userMessage = 'We were unable to log you in because we couldn\'t find your email address. Please make sure you give us access to read your email address.';
+  }
+
+  var options = {
+    form: forms.loginForm,
+    formActionUri: formActionUri,
+    oauthStateToken: oauthStateToken,
+    hasSocialProviders: hasSocialProviders,
+    error: err.userMessage || err.message
+  };
+
+  helpers.render(req, res, view, options);
+}
+
+/**
  * Takes an error object and responds either by
  * rendering the login form with the error, or
  * by returning the error as JSON.
@@ -22,34 +61,6 @@ function oauthErrorResponder(req, res, err) {
   var accepts = req.accepts(['html', 'json']);
   var config = req.app.get('stormpathConfig');
 
-  function renderLoginFormWithError(err) {
-    var view = config.web.login.view;
-    var nextUri = url.parse(req.query.next || '').path;
-    var encodedNextUri = encodeURIComponent(nextUri);
-    var formActionUri = config.web.login.uri + (nextUri ? ('?next=' + encodedNextUri) : '');
-    var oauthStateToken = common.resolveStateToken(req, res);
-
-    var hasSocialProviders = _.some(config.socialProviders, function (socialProvider) {
-      return socialProvider.enabled;
-    });
-
-    // Stormpath is unable to create or update the account because the
-    // Facebook or Google response did not contain the required property.
-    if (err.code === 7201) {
-      err.userMessage = 'We were unable to log you in because we couldn\'t find your email address. Please make sure you give us access to read your email address.';
-    }
-
-    var options = {
-      form: forms.loginForm,
-      formActionUri: formActionUri,
-      oauthStateToken: oauthStateToken,
-      hasSocialProviders: hasSocialProviders,
-      error: err.userMessage || err.message
-    };
-
-    helpers.render(req, res, view, options);
-  }
-
   if (accepts === 'json') {
     var json = err;
 
@@ -62,7 +73,7 @@ function oauthErrorResponder(req, res, err) {
     return res.status(err.status || 400).json(json);
   }
 
-  return renderLoginFormWithError(err);
+  return renderLoginFormWithError(req, res, config, err);
 }
 
 module.exports = oauthErrorResponder;

--- a/lib/oauth/error-responder.js
+++ b/lib/oauth/error-responder.js
@@ -19,6 +19,7 @@ var common = require('./common');
  * @param {Object} err - The error to display.
  */
 function renderLoginFormWithError(req, res, config, err) {
+  var logger = req.app.get('stormpathLogger');
   var view = config.web.login.view;
   var nextUri = url.parse(req.query.next || '').path;
   var encodedNextUri = encodeURIComponent(nextUri);
@@ -32,7 +33,8 @@ function renderLoginFormWithError(req, res, config, err) {
   // Stormpath is unable to create or update the account because the
   // Facebook or Google response did not contain the required property.
   if (err.code === 7201) {
-    err.userMessage = 'We were unable to log you in because we couldn\'t find your email address. Please make sure you give us access to read your email address.';
+    logger.info('Provider login error: ' + err.message);
+    err.userMessage = 'Login failed, because we could not retrieve your email address from the provider.  Please ensure that you have granted email permission to our application.';
   }
 
   var options = {

--- a/lib/oauth/error-responder.js
+++ b/lib/oauth/error-responder.js
@@ -51,7 +51,15 @@ function oauthErrorResponder(req, res, err) {
   }
 
   if (accepts === 'json') {
-    return res.status(err.status || 400).json(err);
+    var json = err;
+
+    // If this is a normal Error object,
+    // just send the message property.
+    if (err.constructor.name === 'Error') {
+      json = { message: err.message };
+    }
+
+    return res.status(err.status || 400).json(json);
   }
 
   return renderLoginFormWithError(err);

--- a/lib/oauth/error-responder.js
+++ b/lib/oauth/error-responder.js
@@ -25,7 +25,8 @@ function oauthErrorResponder(req, res, err) {
   function renderLoginFormWithError(err) {
     var view = config.web.login.view;
     var nextUri = url.parse(req.query.next || '').path;
-    var formActionUri = config.web.login.uri + (nextUri ? ('?next=' + nextUri) : '');
+    var encodedNextUri = encodeURIComponent(nextUri);
+    var formActionUri = config.web.login.uri + (nextUri ? ('?next=' + encodedNextUri) : '');
     var oauthStateToken = common.resolveStateToken(req, res);
 
     var hasSocialProviders = _.some(config.socialProviders, function (socialProvider) {

--- a/lib/oauth/error-responder.js
+++ b/lib/oauth/error-responder.js
@@ -5,11 +5,11 @@ var url = require('url');
 
 var helpers = require('../helpers');
 var forms = require('../forms');
-var resolveStateToken = require('./common').resolveStateToken;
+var common = require('./common');
 
 /**
- * oauthErrorResponder takes an error object and respondes
- * either by rendering the login form with the error, or
+ * Takes an error object and responds either by
+ * rendering the login form with the error, or
  * by returning the error as JSON.
  *
  * @method
@@ -23,18 +23,18 @@ function oauthErrorResponder(req, res, err) {
   var config = req.app.get('stormpathConfig');
 
   function renderLoginFormWithError(err) {
-    var view = req.app.get('stormpathConfig').web.login.view;
+    var view = config.web.login.view;
     var nextUri = url.parse(req.query.next || '').path;
     var formActionUri = config.web.login.uri + (nextUri ? ('?next=' + nextUri) : '');
-    var oauthStateToken = resolveStateToken(req, res);
+    var oauthStateToken = common.resolveStateToken(req, res);
 
     var hasSocialProviders = _.some(config.socialProviders, function (socialProvider) {
       return socialProvider.enabled;
     });
 
+    // Stormpath is unable to create or update the account because the
+    // Facebook or Google response did not contain the required property.
     if (err.code === 7201) {
-      // Stormpath is unable to create or update the account because the
-      // Facebook or Google response did not contain the required property.
       err.userMessage = 'We were unable to log you in because we couldn\'t find your email address. Please make sure you give us access to read your email address.';
     }
 
@@ -49,14 +49,11 @@ function oauthErrorResponder(req, res, err) {
     helpers.render(req, res, view, options);
   }
 
-  switch (accepts) {
-    case 'json':
-      return res.status(err.status || 400).json(err);
-
-    case 'html':
-    default:
-      return renderLoginFormWithError(err);
+  if (accepts === 'json') {
+    return res.status(err.status || 400).json(err);
   }
+
+  return renderLoginFormWithError(err);
 }
 
 module.exports = oauthErrorResponder;

--- a/lib/oauth/index.js
+++ b/lib/oauth/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   common: require('./common'),
-  linkedIn: require('./linkedin')
+  linkedIn: require('./linkedin'),
+  errorResponder: require('./error-responder')
 };

--- a/lib/views/facebook_login_form.jade
+++ b/lib/views/facebook_login_form.jade
@@ -16,6 +16,8 @@ script(type='text/javascript').
         var queryStr = window.location.search.replace('?', '');
         // TODO make dynamic
         if (queryStr) {
+          // Remove existing access token from query string.
+          queryStr = queryStr.replace(/(&?)access_token=([^&]*)/, '');
           window.location.replace('/callbacks/facebook?' + queryStr + '&access_token=' + response.authResponse.accessToken);
         } else {
           window.location.replace('/callbacks/facebook?access_token=' + response.authResponse.accessToken);

--- a/lib/views/facebook_login_form.jade
+++ b/lib/views/facebook_login_form.jade
@@ -16,8 +16,10 @@ script(type='text/javascript').
         var queryStr = window.location.search.replace('?', '');
         // TODO make dynamic
         if (queryStr) {
-          // Remove existing access token from query string.
+          // Don't include any access_token parameters in
+          // the query string as it will be added by us.
           queryStr = queryStr.replace(/(&?)access_token=([^&]*)/, '');
+
           window.location.replace('/callbacks/facebook?' + queryStr + '&access_token=' + response.authResponse.accessToken);
         } else {
           window.location.replace('/callbacks/facebook?access_token=' + response.authResponse.accessToken);

--- a/lib/views/linkedin_login_form.jade
+++ b/lib/views/linkedin_login_form.jade
@@ -15,7 +15,9 @@ script(type='text/javascript').
           serializedQueryString += '&';
         }
 
-        serializedQueryString += key + '=' + encodeURIComponent(value);
+        if (key !== 'access_token') {
+          serializedQueryString += key + '=' + encodeURIComponent(value);
+        }
       }
 
       result += '?' + serializedQueryString;

--- a/lib/views/linkedin_login_form.jade
+++ b/lib/views/linkedin_login_form.jade
@@ -15,9 +15,13 @@ script(type='text/javascript').
           serializedQueryString += '&';
         }
 
-        if (key !== 'access_token') {
-          serializedQueryString += key + '=' + encodeURIComponent(value);
+        // Don't include any access_token parameters in
+        // the query string as it will be added by LinkedIn.
+        if (key === 'access_token') {
+          continue;
         }
+
+        serializedQueryString += key + '=' + encodeURIComponent(value);
       }
 
       result += '?' + serializedQueryString;


### PR DESCRIPTION
Fixes #288.

Errors during social login is today displayed as json (see #288). This PR fixes so that the error is instead displayed as an error on the login form. It also shows a more specific error message when email was not provided.

**Please see *Discussion* before reviewing.**

### Discussion

After I've made this, I found out that there are views for displaying social login errors (e.g. `facebook_login_failed.jade`), but they doesn't seem to be used.

However, I found it better to display the error on the login form as it allows the user to try again.

Question is, what solution should I go with? Implementing the error views or use the login form as this PR does? If the latter, I should probably show the registration form instead if the error occurred during signup, which is not possible to know at the moment.

### How to verify

1. **Checkout `master`.**
2. Clone the [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project).
3. Link to express-stormpath (`npm link` and `npm link express-stormpath`)
4. Configure it with a Facebook Directory.
5. Try to login with Facebook, but in the login popup, choose to not share your email address.
6. Verify that you get an error response in form of json.
7. **Checkout this branch.**
8. Try to login again.
9. Verify that you get the error on the login form instead (*see screenshot*)
10. Also verify that the error message has been rewritten to state that must you share your email.
11. Browse to <http://localhost:3000/callbacks/facebook?&access_token=sdssdsd> with an invalid access token.
12. Verify that you get another error message.
13. Try the same for Google and LinkedIn.

### Screenshots

<img width="637" alt="screen shot 2016-02-08 at 13 36 44" src="https://cloud.githubusercontent.com/assets/721091/12885800/11946968-ce69-11e5-94d6-99a68c40891e.png">
