### PR TITLE
JSON view model for GET on /login

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -91,6 +91,24 @@ web:
     uri: "/login"
     nextUri: "/"
     view: "login"
+    fields:
+      login:
+        enabled: true
+        label: "Username or Email"
+        name: "login"
+        placeholder: "Username or Email"
+        required: true
+        type: "text"
+      password:
+        enabled: true
+        label: "Password"
+        name: "password"
+        placeholder: "Password"
+        required: true
+        type: "password"
+    fieldOrder:
+      - "login"
+      - "password"
   logout:
     enabled: false
     uri: "/logout"

--- a/lib/controllers/login.js
+++ b/lib/controllers/login.js
@@ -10,7 +10,7 @@ var forms = require('../forms');
 var helpers = require('../helpers');
 var oauth = require('../oauth');
 var loginWithOAuthProvider = require('../helpers/login-with-oauth-provider');
-var getLoginViewModel = require('../helpers/get-login-view-model');
+var getLoginViewModel = require('../helpers/get-login-view-model').default;
 
 /**
  * This controller logs in an existing user.  If there are any errors, an

--- a/lib/controllers/login.js
+++ b/lib/controllers/login.js
@@ -10,6 +10,7 @@ var forms = require('../forms');
 var helpers = require('../helpers');
 var oauth = require('../oauth');
 var loginWithOAuthProvider = require('../helpers/login-with-oauth-provider');
+var getLoginViewModel = require('../helpers/get-login-view-model');
 
 /**
  * This controller logs in an existing user.  If there are any errors, an
@@ -50,6 +51,20 @@ module.exports = function (req, res) {
     });
 
     helpers.render(req, res, view, options);
+  }
+
+  // If a GET request is made with the Accept header as json,
+  // respond with the view model for this form.
+  // TODO: When `stormpath.web.produces` is implemented,
+  // this `if` must check that it is set to `application/json`.
+  if (req.method === 'GET' && accepts === 'json') {
+    return getLoginViewModel(config, function (err, viewModel) {
+      if (err) {
+        return res.status(400).json({ error: err.userMessage || err.message });
+      }
+
+      res.status(200).json(viewModel);
+    });
   }
 
   if (req.user && config.web.login.enabled) {

--- a/lib/controllers/login.js
+++ b/lib/controllers/login.js
@@ -10,7 +10,6 @@ var forms = require('../forms');
 var helpers = require('../helpers');
 var oauth = require('../oauth');
 var loginWithOAuthProvider = require('../helpers/login-with-oauth-provider');
-var getLoginViewModel = require('../helpers/get-login-view-model').default;
 
 /**
  * This controller logs in an existing user.  If there are any errors, an
@@ -58,7 +57,7 @@ module.exports = function (req, res) {
   // TODO: When `stormpath.web.produces` is implemented,
   // this `if` must check that it is set to `application/json`.
   if (req.method === 'GET' && accepts === 'json') {
-    return getLoginViewModel(config, function (err, viewModel) {
+    return helpers.getLoginViewModel(config, function (err, viewModel) {
       if (err) {
         return res.status(400).json({ error: err.userMessage || err.message });
       }

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -158,10 +158,12 @@ function getLoginViewModel(config, callback) {
   });
 }
 
-module.exports = getLoginViewModel;
+module.exports = {
+  default: getLoginViewModel,
 
-// Expose private functions for testing.
-getLoginViewModel.prototype.getFormFields = getFormFields;
-getLoginViewModel.prototype.getAccountStores = getAccountStores;
-getLoginViewModel.prototype.getAccountStoreModel = getAccountStoreModel;
-getLoginViewModel.prototype.getProviders = getProviders;
+  // Expose private functions for testing.
+  getFormFields: getFormFields,
+  getAccountStores: getAccountStores,
+  getAccountStoreModel: getAccountStoreModel,
+  getProviders: getProviders
+};

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -3,6 +3,8 @@
 var _ = require('lodash');
 var async = require('async');
 
+var cachedViewModel;
+
 /**
  * Returns list of all enabled fields, as defined by `stormpath.web.login.fields`,
  * and ordered by `stormpath.web.login.fieldOrder`.
@@ -131,6 +133,10 @@ function getProviders(config, callback) {
  * @param {Function} callback - Callback function (error, model).
  */
 function getLoginViewModel(config, callback) {
+  if (cachedViewModel) {
+    return callback(null, cachedViewModel);
+  }
+
   var fields = getFormFields(config);
 
   var model = {
@@ -146,6 +152,7 @@ function getLoginViewModel(config, callback) {
     }
 
     model.accountStores = providers;
+    cachedViewModel = model;
 
     callback(null, model);
   });

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -4,6 +4,37 @@ var _ = require('lodash');
 var async = require('async');
 
 var cachedViewModel;
+var cacheTimestamp = 0;
+
+/**
+ * Returns the cached model if it's not older than `ttl`.
+ * Else it returns null.
+ *
+ * @method
+ *
+ * @param {number} ttl - The time-to-live value for the cached object.
+ */
+function getCachedModel(ttl) {
+  var age = (new Date().getTime() - cacheTimestamp) / 1000; // In seconds.
+
+  if (cachedViewModel && age <= ttl) {
+    return cachedViewModel;
+  }
+
+  return null;
+}
+
+/**
+ * Saves the model in "cache" together with a timestamp.
+ *
+ * @method
+ *
+ * @param {Object} model - The model to cache.
+ */
+function setCachedModel(model) {
+  cachedViewModel = model;
+  cacheTimestamp = new Date().getTime();
+}
 
 /**
  * Returns list of all enabled fields, as defined by `stormpath.web.login.fields`,
@@ -134,9 +165,10 @@ function getProviders(config, callback) {
  */
 function getLoginViewModel(config, callback) {
   var cacheTtl = config.client.cacheManager.defaultTtl;
+  var cached = getCachedModel(cacheTtl);
 
-  if (cachedViewModel) {
-    return callback(null, cachedViewModel);
+  if (cached) {
+    return callback(null, cached);
   }
 
   var fields = getFormFields(config);
@@ -154,12 +186,8 @@ function getLoginViewModel(config, callback) {
     }
 
     model.accountStores = providers;
-    cachedViewModel = model;
 
-    // Set timer to clear cache.
-    setTimeout(function () {
-      cachedViewModel = null;
-    }, cacheTtl * 1000);
+    setCachedModel(model);
 
     callback(null, model);
   });

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('lodash');
-var async = require('async');
 
 var cachedViewModel;
 var cacheTimestamp = 0;
@@ -85,7 +84,7 @@ function getAccountStores(application, callback) {
     }
 
     // Get account stores.
-    async.map(accountStoreMappings.items, function (accountStoreMapping, done) {
+    accountStoreMappings.map(function (accountStoreMapping, done) {
       accountStoreMapping.getAccountStore({ expand: 'provider' }, done);
     }, callback);
   });

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -167,7 +167,9 @@ function getLoginViewModel(config, callback) {
   var cachedModel = getCachedModel(cacheTtl);
 
   if (cachedModel) {
-    return callback(null, cachedModel);
+    return process.nextTick(function () {
+      callback(null, cachedModel);
+    });
   }
 
   var fields = getFormFields(config);

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -164,10 +164,10 @@ function getProviders(config, callback) {
  */
 function getLoginViewModel(config, callback) {
   var cacheTtl = config.client.cacheManager.defaultTtl;
-  var cached = getCachedModel(cacheTtl);
+  var cachedModel = getCachedModel(cacheTtl);
 
-  if (cached) {
-    return callback(null, cached);
+  if (cachedModel) {
+    return callback(null, cachedModel);
   }
 
   var fields = getFormFields(config);

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -1,0 +1,125 @@
+'use strict';
+
+var _ = require('lodash');
+var async = require('async');
+
+/**
+ * Returns list of all enabled fields, as defined by `stormpath.web.login.fields`,
+ * and ordered by `stormpath.web.login.fieldOrder`.
+ *
+ * @method
+ *
+ * @param {Object} config - The Stormpath configuration.
+ */
+function getFormFields(config) {
+  // Get fields by fieldOrder.
+  var fields = config.web.login.fieldOrder.map(function (fieldName) {
+    return config.web.login.fields[fieldName];
+  });
+
+  // Filter out only the enabled fields.
+  fields = fields.filter(function (field) {
+    return field && field.enabled;
+  });
+
+  // Remove the `enabled` property.
+  fields = fields.map(function (field) {
+    var copy = _.clone(field);
+
+    delete copy.enabled;
+
+    return copy;
+  });
+
+  return fields;
+}
+
+/**
+ * Returns a list of all available providers
+ * (such as Facebook and SAML Directories).
+ *
+ * @method
+ *
+ * @param {Object} config - The Stormpath configuration.
+ * @param {Function} callback - Callback function (error, providers).
+ */
+function getProviders(config, callback) {
+  var application = config.application;
+  var options = { expand: 'accountStore' };
+
+  // Get account store mappings.
+  application.getAccountStoreMappings(options, function (err, accountStoreMappings) {
+    if (err) {
+      return callback(err);
+    }
+
+    // Get account stores.
+    async.map(accountStoreMappings.items, function (accountStoreMapping, done) {
+      accountStoreMapping.getAccountStore({ expand: 'provider' }, done);
+    }, function (err, accountStores) {
+      if (err) {
+        return callback(err);
+      }
+
+      // Filter out only enabled account stores with providers.
+      accountStores = accountStores.filter(function (accountStore) {
+        return accountStore.status === 'ENABLED' && accountStore.provider;
+      });
+
+      // Map account stores to only expose certain fields.
+      var providers = accountStores.map(function (accountStore) {
+        var provider = accountStore.provider;
+
+        return {
+          href: accountStore.href,
+          name: accountStore.name,
+          provider: {
+            href: provider.href,
+            providerId: provider.providerId,
+            callbackUri: provider.callbackUri,
+            clientId: provider.clientId
+          }
+        };
+      });
+
+      callback(null, providers);
+    });
+  });
+}
+
+/**
+ * Returns an object containing:
+ *
+ * - A list of all enabled fields, as defined by `stormpath.web.login.fields`,
+ *   and ordered by `stormpath.web.login.fieldOrder`.
+ * - A list of providers, such as social providers or SAML providers.
+ *
+ * <https://github.com/stormpath/stormpath-framework-spec/blob/master/login.md#login-view-model>
+ *
+ * @method
+ *
+ * @param {Object} config - The Stormpath configuration.
+ * @param {Function} callback - Callback function (error, model).
+ */
+function getLoginViewModel(config, callback) {
+  var fields = getFormFields(config);
+
+  var model = {
+    form: {
+      fields: fields
+    },
+    accountStores: null
+  };
+
+  getProviders(config, function (err, providers) {
+    if (err) {
+      return callback(err);
+    }
+
+    model.accountStores = providers;
+
+    callback(null, model);
+  });
+}
+
+module.exports = getLoginViewModel;

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -99,9 +99,12 @@ function getProviders(config, callback) {
       return callback(err);
     }
 
-    // Filter out only enabled account stores with providers.
+    // Filter out only enabled non-stormpath account store providers.
     accountStores = accountStores.filter(function (accountStore) {
-      return accountStore.status === 'ENABLED' && accountStore.provider;
+      var isStormpathProvider = accountStore.provider.providerId === 'stormpath';
+      var isEnabled = accountStore.status === 'ENABLED';
+
+      return isEnabled && !isStormpathProvider;
     });
 
     // Map account stores to only expose certain fields.

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -149,3 +149,9 @@ function getLoginViewModel(config, callback) {
 }
 
 module.exports = getLoginViewModel;
+
+// Expose private functions for testing.
+getLoginViewModel.prototype.getFormFields = getFormFields;
+getLoginViewModel.prototype.getAccountStores = getAccountStores;
+getLoginViewModel.prototype.getAccountStoreModel = getAccountStoreModel;
+getLoginViewModel.prototype.getProviders = getProviders;

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -133,6 +133,8 @@ function getProviders(config, callback) {
  * @param {Function} callback - Callback function (error, model).
  */
 function getLoginViewModel(config, callback) {
+  var cacheTtl = config.client.cacheManager.defaultTtl;
+
   if (cachedViewModel) {
     return callback(null, cachedViewModel);
   }
@@ -153,6 +155,11 @@ function getLoginViewModel(config, callback) {
 
     model.accountStores = providers;
     cachedViewModel = model;
+
+    // Set timer to clear cache.
+    setTimeout(function () {
+      cachedViewModel = null;
+    }, cacheTtl * 1000);
 
     callback(null, model);
   });

--- a/lib/helpers/get-login-view-model.js
+++ b/lib/helpers/get-login-view-model.js
@@ -35,16 +35,14 @@ function getFormFields(config) {
 }
 
 /**
- * Returns a list of all available providers
- * (such as Facebook and SAML Directories).
+ * Returns a list of account stores for the specified application.
  *
  * @method
  *
- * @param {Object} config - The Stormpath configuration.
+ * @param {Object} application - The Stormpath Application to get account stores from.
  * @param {Function} callback - Callback function (error, providers).
  */
-function getProviders(config, callback) {
-  var application = config.application;
+function getAccountStores(application, callback) {
   var options = { expand: 'accountStore' };
 
   // Get account store mappings.
@@ -56,34 +54,62 @@ function getProviders(config, callback) {
     // Get account stores.
     async.map(accountStoreMappings.items, function (accountStoreMapping, done) {
       accountStoreMapping.getAccountStore({ expand: 'provider' }, done);
-    }, function (err, accountStores) {
-      if (err) {
-        return callback(err);
-      }
+    }, callback);
+  });
+}
 
-      // Filter out only enabled account stores with providers.
-      accountStores = accountStores.filter(function (accountStore) {
-        return accountStore.status === 'ENABLED' && accountStore.provider;
-      });
+/**
+ * Takes an account store object and returns a
+ * new object with only the fields that we want
+ * to expose to the public.
+ *
+ * @method
+ *
+ * @param {Object} accountStore - The account store.
+ */
+function getAccountStoreModel(accountStore) {
+  var provider = accountStore.provider;
 
-      // Map account stores to only expose certain fields.
-      var providers = accountStores.map(function (accountStore) {
-        var provider = accountStore.provider;
+  return {
+    href: accountStore.href,
+    name: accountStore.name,
+    provider: {
+      href: provider.href,
+      providerId: provider.providerId,
+      callbackUri: provider.callbackUri,
+      clientId: provider.clientId
+    }
+  };
+}
 
-        return {
-          href: accountStore.href,
-          name: accountStore.name,
-          provider: {
-            href: provider.href,
-            providerId: provider.providerId,
-            callbackUri: provider.callbackUri,
-            clientId: provider.clientId
-          }
-        };
-      });
+/**
+ * Returns a list of all available providers
+ * (such as Facebook and SAML Directories).
+ *
+ * @method
+ *
+ * @param {Object} config - The Stormpath configuration.
+ * @param {Function} callback - Callback function (error, providers).
+ */
+function getProviders(config, callback) {
+  var application = config.application;
 
-      callback(null, providers);
+  getAccountStores(application, function (err, accountStores) {
+    if (err) {
+      return callback(err);
+    }
+
+    // Filter out only enabled account stores with providers.
+    accountStores = accountStores.filter(function (accountStore) {
+      return accountStore.status === 'ENABLED' && accountStore.provider;
     });
+
+    // Map account stores to only expose certain fields.
+    var providers = accountStores.map(function (accountStore) {
+      return getAccountStoreModel(accountStore);
+    });
+
+    callback(null, providers);
   });
 }
 

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -19,5 +19,6 @@ module.exports = {
   setTempCookie: require('./set-temp-cookie'),
   validateAccount: require('./validate-account'),
   xsrfValidator: require('./xsrf-validator'),
-  revokeToken: require('./revoke-token')
+  revokeToken: require('./revoke-token'),
+  getLoginViewModel: require('./get-login-view-model').default
 };

--- a/test/helpers/test-get-login-view-model.js
+++ b/test/helpers/test-get-login-view-model.js
@@ -1,0 +1,153 @@
+'use strict';
+
+var assert = require('assert');
+var getLoginViewModel = require('../../lib/helpers/get-login-view-model');
+
+function getMockConfig() {
+  return {
+    web: {
+      login: {
+        fields: {
+          'enabled': {
+            name: 'enabled',
+            enabled: true,
+            _enabled: true
+          },
+          'enabled2': {
+            name: 'enabled2',
+            enabled: true,
+            _enabled: true
+          },
+          'disabled': {
+            name: 'disabled',
+            enabled: false,
+            _enabled: false
+          }
+        },
+        fieldOrder: [
+          'disabled',
+          'enabled2',
+          'enabled'
+        ]
+      }
+    }
+  };
+}
+
+function getMockAccountStore() {
+  return {
+    href: '9d7cbfae-f5f0-4e4d-ac6b-c94b429cc081',
+    name: '0fee67c8-cac5-4c44-b2e8-834487aea177',
+    provider: {
+      href: '321ae5b5-a8e2-49f7-a53f-7dc74822b60f',
+      providerId: 'aeb07d2d-5234-4deb-afa5-89cbe480f5a3',
+      callbackUri: '4a991672-d690-48c3-84ff-261e7bb88921',
+      clientId: '99a534c8-2812-4c6c-b191-549fd88f749b',
+      clientSecret: 'cc85f677-98ad-465e-bb49-a97473e5d06d'
+    }
+  };
+}
+
+describe('helpers/get-login-view-model.js', function () {
+  var config;
+
+  beforeEach(function () {
+    config = getMockConfig();
+  });
+
+  describe('getFormFields(config)', function () {
+    var getFormFields;
+    var returnValue;
+
+    beforeEach(function () {
+      getFormFields = getLoginViewModel.prototype.getFormFields;
+      returnValue = getFormFields(config);
+    });
+
+    it('should return a non-empty array', function () {
+      assert(Array.isArray(returnValue));
+      assert(returnValue.length > 0);
+    });
+
+    it('should only return fields with `enabled` set to `true`', function () {
+      returnValue.forEach(function (value) {
+        // Check `_enabled` as `enabled` has been removed from the result.
+        assert(value._enabled === true);
+      });
+    });
+
+    it('should remove the `enabled` property from returned fields', function () {
+      returnValue.forEach(function (value) {
+        assert.equal(value.enabled, undefined);
+      });
+    });
+
+    it('should return the fields in order of `config.web.login.fieldOrder`', function () {
+      var fieldOrder = config.web.login.fieldOrder;
+
+      var index = returnValue.map(function (value) {
+        return fieldOrder.indexOf(value.name);
+      });
+
+      // Copy index array and sort it.
+      var sortedIndex = index.slice();
+      sortedIndex.sort();
+
+      assert.deepEqual(index, sortedIndex);
+    });
+  });
+
+  describe('getAccountStoreModel(accountStore)', function () {
+    var getAccountStoreModel;
+    var accountStore;
+    var returnValue;
+
+    beforeEach(function () {
+      getAccountStoreModel = getLoginViewModel.prototype.getAccountStoreModel;
+      accountStore = getMockAccountStore();
+      returnValue = getAccountStoreModel(accountStore);
+    });
+
+    it('should return an object', function () {
+      assert(typeof returnValue === 'object');
+    });
+
+    describe('return object', function () {
+      it('should not be the accountStore object', function () {
+        assert.notEqual(returnValue, accountStore);
+      });
+
+      it('should have href of accountStore', function () {
+        assert.equal(returnValue.href, accountStore.href);
+      });
+
+      it('should have name of accountStore', function () {
+        assert.equal(returnValue.name, accountStore.name);
+      });
+
+      describe('.provider', function () {
+        var provider;
+
+        beforeEach(function () {
+          provider = returnValue.provider;
+        });
+
+        it('should have href of accountStore.provider', function () {
+          assert.equal(provider.href, accountStore.provider.href);
+        });
+
+        it('should have callbackUri of accountStore.provider', function () {
+          assert.equal(provider.callbackUri, accountStore.provider.callbackUri);
+        });
+
+        it('should have clientId of accountStore.provider', function () {
+          assert.equal(provider.clientId, accountStore.provider.clientId);
+        });
+
+        it('should not have a clientSecret property', function () {
+          assert.equal(provider.clientSecret, undefined);
+        });
+      });
+    });
+  });
+});

--- a/test/helpers/test-get-login-view-model.js
+++ b/test/helpers/test-get-login-view-model.js
@@ -60,7 +60,7 @@ describe('helpers/get-login-view-model.js', function () {
     var returnValue;
 
     beforeEach(function () {
-      getFormFields = getLoginViewModel.prototype.getFormFields;
+      getFormFields = getLoginViewModel.getFormFields;
       returnValue = getFormFields(config);
     });
 
@@ -103,7 +103,7 @@ describe('helpers/get-login-view-model.js', function () {
     var returnValue;
 
     beforeEach(function () {
-      getAccountStoreModel = getLoginViewModel.prototype.getAccountStoreModel;
+      getAccountStoreModel = getLoginViewModel.getAccountStoreModel;
       accountStore = getMockAccountStore();
       returnValue = getAccountStoreModel(accountStore);
     });


### PR DESCRIPTION
Fixes #306.

This PR implements a JSON view model for `GET` on `/login` according to the [spec](https://github.com/stormpath/stormpath-framework-spec/blob/master/login.md#login-view-model).

### Notes

* This PR is going to be merged into `framework-spec-upgrade`.

* I'm not sure if the account stores should only include SAML and social providers, or just all of them. If so, how do I filter them out?

* Added some unit tests (all methods are not tested):

  ```bash
helpers/get-login-view-model.js
  getFormFields(config)
    ✓ should return a non-empty array
    ✓ should only return fields with `enabled` set to `true`
    ✓ should remove the `enabled` property from returned fields
    ✓ should return the fields in order of `config.web.login.fieldOrder`
  getAccountStoreModel(accountStore)
    ✓ should return an object
    return object
      ✓ should not be the accountStore object
      ✓ should have href of accountStore
      ✓ should have name of accountStore
      .provider
        ✓ should have href of accountStore.provider
        ✓ should have callbackUri of accountStore.provider
        ✓ should have clientId of accountStore.provider
        ✓ should not have a clientSecret property
```

### How to verify

1. Checkout this branch
2. Clone [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project)
3. Use `npm link` and `npm link express-stormpath` to link the library to the example project
4. Make a `GET` request to `/login` with the `Accept` header set to `application/json`
5. Verify that you get a JSON model back according to the [spec](https://github.com/stormpath/stormpath-framework-spec/blob/master/login.md#login-view-model)
6. Try to edit the config (`web.login.fields` and `web.login.fieldOrder`) and verify that the fields and its order are correct
7. Verify the content of `accountStores` and see my notes about it
