### PR TITLE
Implement support for GitHub social login

### DIFF
--- a/lib/controllers/github-login.js
+++ b/lib/controllers/github-login.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var url = require('url');
+
+var helpers = require('../helpers');
+var oauth = require('../oauth');
+
+/**
+ * This controller logs in a user with GitHub OAuth.
+ *
+ * When a user logs in with GitHub (using JavaScript), GitHub will redirect the
+ * user to this view, along with an access code for the user.
+ *
+ * What we do here is grab this access code, exchange it for an access token
+ * using the GitHub API, and lastly send it to Stormpath to handle the OAuth
+ * negotiation. Once this is done, we log this user in using normal sessions,
+ * and from this point on -- this user is treated like a normal system user!
+ *
+ * @method
+ *
+ * @param {Object} req - The http request.
+ * @param {Object} res - The http response.
+ */
+module.exports = function (req, res) {
+  var application = req.app.get('stormpathApplication');
+  var config = req.app.get('stormpathConfig');
+  var logger = req.app.get('stormpathLogger');
+  var loginHandler = config.postLoginHandler;
+  var registrationHandler = config.postRegistrationHandler;
+  var provider = config.socialProviders.github;
+  var baseUrl = req.protocol + '://' + req.get('host');
+  var authUrl = 'https://github.com/login/oauth/access_token';
+  var code = req.query.code;
+
+  if (!code) {
+    logger.info('A user attempted to log in via GitHub OAuth without specifying an OAuth token.');
+    return oauth.errorResponder(req, res, new Error('code parameter required.'));
+  }
+
+  oauth.common.exchangeAuthCodeForAccessToken(authUrl, code, baseUrl, provider, function (err, accessToken) {
+    if (err) {
+      logger.info('During a GitHub OAuth login attempt, we were unable to exchange the authentication code for an access token.');
+      return oauth.errorResponder(req, res, err);
+    }
+
+    var userData = {
+      providerData: {
+        accessToken: accessToken,
+        providerId: 'github'
+      }
+    };
+
+    application.getAccount(userData, function (err, resp) {
+      if (err) {
+        logger.info('During a GitHub OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
+        return oauth.errorResponder(req, res, err);
+      }
+
+      helpers.expandAccount(req.app, resp.account, function (err, expandedAccount) {
+        if (err) {
+          logger.info('During a GitHub OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
+          return oauth.errorResponder(req, res, err);
+        }
+
+        res.locals.user = expandedAccount;
+        req.user = expandedAccount;
+
+        helpers.createStormpathSession(req.user, req, res, function (err) {
+          if (err) {
+            logger.info('During a GitHub OAuth login attempt, we were unable to create a Stormpath session.');
+            return oauth.errorResponder(req, res, err);
+          }
+
+          var nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+
+          if (resp.created && registrationHandler) {
+            registrationHandler(req.user, req, res, function () {
+              res.redirect(302, nextUrl);
+            });
+          } else if (loginHandler) {
+            loginHandler(req.user, req, res, function () {
+              res.redirect(302, nextUrl);
+            });
+          } else {
+            res.redirect(302, nextUrl);
+          }
+        });
+      });
+    });
+  });
+};

--- a/lib/controllers/github-login.js
+++ b/lib/controllers/github-login.js
@@ -37,7 +37,7 @@ module.exports = function (req, res) {
     return oauth.errorResponder(req, res, new Error('code parameter required.'));
   }
 
-  oauth.common.exchangeAuthCodeForAccessToken(authUrl, code, baseUrl, provider, function (err, accessToken) {
+  oauth.common.exchangeAuthCodeForAccessToken(authUrl, code, req.cookies.oauthStateToken, baseUrl, provider, function (err, accessToken) {
     if (err) {
       logger.info('During a GitHub OAuth login attempt, we were unable to exchange the authentication code for an access token.');
       return oauth.errorResponder(req, res, err);

--- a/lib/controllers/index.js
+++ b/lib/controllers/index.js
@@ -9,6 +9,7 @@ module.exports = {
   idSiteRedirect: require('./id-site-redirect'),
   idSiteVerify: require('./id-site-verify'),
   linkedInLogin: require('./linkedin-login'),
+  githubLogin: require('./github-login'),
   login: require('./login'),
   logout: require('./logout'),
   register: require('./register'),

--- a/lib/oauth/common.js
+++ b/lib/oauth/common.js
@@ -108,6 +108,10 @@ module.exports = {
         return callback(err);
       }
 
+      if (parsedBody.error) {
+        return callback(new Error(parsedBody.error));
+      }
+
       callback(err, parsedBody.access_token);
     });
   }

--- a/lib/oauth/common.js
+++ b/lib/oauth/common.js
@@ -85,14 +85,15 @@ module.exports = {
    * @param {Object} provider - The provider object that contains the client id, secret, and callbackUri.
    * @param {Function} callback - The callback to call once a response has been resolved.
    */
-  exchangeAuthCodeForAccessToken: function (authUrl, code, baseUrl, provider, callback) {
+  exchangeAuthCodeForAccessToken: function (authUrl, code, oauthStateToken, baseUrl, provider, callback) {
     var options = {
       form: {
         grant_type: 'authorization_code',
         code: code,
         redirect_uri: baseUrl + provider.callbackUri,
         client_id: provider.clientId,
-        client_secret: provider.clientSecret
+        client_secret: provider.clientSecret,
+        state: oauthStateToken
       },
       headers: {
         Accept: 'application/json'

--- a/lib/oauth/common.js
+++ b/lib/oauth/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var uuid = require('uuid');
+var request = require('request');
 
 var helpers = require('../helpers');
 
@@ -70,5 +71,44 @@ module.exports = {
     }
 
     return redirectTo;
+  },
+
+  /**
+   * Exchange an authentication code for an OAuth access token.
+   *
+   * @method
+   * @private
+   *
+   * @param {string} authUrl - The url to use to make the exchange.
+   * @param {string} code - The authentication code.
+   * @param {string} baseUrl - The base url to prepend to the callback uri.
+   * @param {Object} provider - The provider object that contains the client id, secret, and callbackUri.
+   * @param {Function} callback - The callback to call once a response has been resolved.
+   */
+  exchangeAuthCodeForAccessToken: function (authUrl, code, baseUrl, provider, callback) {
+    var options = {
+      form: {
+        grant_type: 'authorization_code',
+        code: code,
+        redirect_uri: baseUrl + provider.callbackUri,
+        client_id: provider.clientId,
+        client_secret: provider.clientSecret
+      },
+      headers: {
+        Accept: 'application/json'
+      }
+    };
+
+    request.post(authUrl, options, function (err, result, body) {
+      var parsedBody;
+
+      try {
+        parsedBody = JSON.parse(body);
+      } catch (err) {
+        return callback(err);
+      }
+
+      callback(err, parsedBody.access_token);
+    });
   }
 };

--- a/lib/views/base.jade
+++ b/lib/views/base.jade
@@ -141,6 +141,22 @@ html(class='no-js', lang='en')
         -ms-filter: "progid:DXImageTransform.Microsoft.gradient (GradientType=0, startColorstr=#007cbc, endColorstr=#0077B5)";
       }
 
+      .btn-github {
+        background: -webkit-linear-gradient(#848282 50%, #7B7979 50%);
+        background: linear-gradient(#848282 50%, #7B7979 50%);
+        filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#848282, endColorstr=#7B7979);
+        -ms-filter: "progid:DXImageTransform.Microsoft.gradient (GradientType=0, startColorstr=#848282, endColorstr=#7B7979)";
+      }
+
+      .btn-github:hover,
+      .btn-github:focus {
+        color: #fff;
+        background: -webkit-linear-gradient(#8C8888 50%, #848080 50%);
+        background: linear-gradient(#8C8888 50%, #848080 50%);
+        filter: progid:DXImageTransform.Microsoft.gradient(GradientType=0, startColorstr=#8C8888, endColorstr=#848080);
+        -ms-filter: "progid:DXImageTransform.Microsoft.gradient (GradientType=0, startColorstr=#8C8888, endColorstr=#848080)";
+      }
+
       .btn-register {
         font-size: 16px;
       }

--- a/lib/views/github_login_form.jade
+++ b/lib/views/github_login_form.jade
@@ -4,11 +4,13 @@ script(type='text/javascript').
     var clientId = '#{stormpathConfig.socialProviders.github.clientId}';
     var scopes = 'user:email, #{stormpathConfig.socialProviders.github.scopes}';
     var redirectUri = '#{url}#{stormpathConfig.socialProviders.github.callbackUri}';
+    var oauthStateToken = '#{oauthStateToken}';
 
     var url = 'https://github.com/login/oauth/authorize' +
       '?client_id=' + encodeURIComponent(clientId) +
       '&scope=' + encodeURIComponent(scopes) +
-      '&redirect_uri=' + encodeURIComponent(redirectUri);
+      '&redirect_uri=' + encodeURIComponent(redirectUri) +
+      '&state=' + encodeURIComponent(oauthStateToken);
 
     window.location = url;
   }

--- a/lib/views/github_login_form.jade
+++ b/lib/views/github_login_form.jade
@@ -1,0 +1,14 @@
+button.btn.btn-social.btn-github(onclick='githubLogin()') GitHub
+script(type='text/javascript').
+  function githubLogin() {
+    var clientId = '#{stormpathConfig.socialProviders.github.clientId}';
+    var scopes = 'user:email, #{stormpathConfig.socialProviders.github.scopes}';
+    var redirectUri = '#{url}#{stormpathConfig.socialProviders.github.callbackUri}';
+
+    var url = 'https://github.com/login/oauth/authorize' +
+      '?client_id=' + encodeURIComponent(clientId) +
+      '&scope=' + encodeURIComponent(scopes) +
+      '&redirect_uri=' + encodeURIComponent(redirectUri);
+
+    window.location = url;
+  }

--- a/lib/views/login.jade
+++ b/lib/views/login.jade
@@ -127,6 +127,8 @@ block body
                 include google_login_form.jade
               if socialProviders.linkedin && socialProviders.linkedin.enabled
                 include linkedin_login_form.jade
+              if socialProviders.github && socialProviders.github.enabled
+                include github_login_form.jade
 
         if stormpathConfig.web.verifyEmail.enabled
           a.forgot(style="float:left", href="#{stormpathConfig.web.verifyEmail.uri}") Resend Verification Email?


### PR DESCRIPTION
Fixes #312.

This PR implements support for GitHub [social login](https://github.com/stormpath/stormpath-framework-spec/blob/master/social.md#feature-description).

This implementation is more or less just a copy of the Google and LinkedIn implementations. I decided to not do any refactors as it will be easier to do them all together later.

I also used `exchangeAuthCodeForAccessToken()` from the LinkedIn implementation and placed it in `oauth/common.js` with some minor changes. I've not refactored LinkedIn to use this new method as that would create more review work.

### Notes

* This PR is going to be merged into `framework-spec-upgrade`.

* If at least four providers are configured, they will take up too much visual space (see the screenshot). One suggestion to fix this could be to vertically center the buttons?

* I decided to make the button darker grey as normal grey could be mistaken as *disabled* according to the SAML button discussions. Any comments?

### How to verify

1. Checkout this branch
2. Clone [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project)
3. Use `npm link` and `npm link express-stormpath` to link the library to the example project
4. Configure a GitHub Directory
5. Start your app and verify that you get the GitHub button on the login form
6. Try to login and verify that you get logged in and that the user is being created
7. See my notes above

### Screenshots

<img width="644" alt="screen shot 2016-02-11 at 17 22 11" src="https://cloud.githubusercontent.com/assets/721091/12982572/9a1e1c7e-d0e5-11e5-8d97-4edd18dc1a84.png">