### PR TITLE
Add web.socialProviders.callbackRoot to the config

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -22,6 +22,8 @@ web:
     secure: null
     path: "/"
     domain: null
+  socialProviders:
+    callbackRoot: "/callbacks"
   # The registration feature will be automatically enabled by the existence of
   # a default account store for your application.
   register:


### PR DESCRIPTION
This PR only changes the default config to include the new config parameter `web.socialProviders.callbackRoot`. The actual functionality is handled in the node config (https://github.com/stormpath/stormpath-node-config/issues/32).

### Discussion

* The [spec](https://github.com/stormpath/stormpath-framework-spec/blob/master/social.md#implementing-page-based-workflows) says that the callback url should be built like this:

  > `/<stormpath.web.socialProviders.callbackRoot>/<providerId>`

  That would mean that `stormpath.web.socialProviders.callbackRoot` would not start with a `/`, and would instead be just `callbacks`.

  To be consistent with other paths/URIs in the config, I decided to include the `/` at the beginning, i.e. `/callbacks`. Whether what is correct or not, this should be corrected/clarified in the specs.

* The current social providers are located at `stormpath.socialProviders` (without `web`). Is this intentional or should this be changed as well?

### How to review

* Make sure that the config parameter looks correct and its default value
* Look at the *Discussion* before merging
