### PR TITLE
Add web.spa option support

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -2,7 +2,7 @@
 web:
   spa:
     enabled: false
-    view: index
+    view: null
   produces:
     - text/html
     - application/json

--- a/lib/config.yml
+++ b/lib/config.yml
@@ -1,5 +1,8 @@
 ---
 web:
+  spa:
+    enabled: false
+    view: index
   produces:
     - text/html
     - application/json

--- a/lib/controllers/login.js
+++ b/lib/controllers/login.js
@@ -65,7 +65,7 @@ module.exports = function (req, res, next) {
 
   res.locals.status = req.query.status;
 
-  helpers.handleAcceptRequest(req, {
+  helpers.handleAcceptRequest(req, res, {
     'application/json': function () {
       switch (req.method) {
         case 'GET':

--- a/lib/controllers/verify-email.js
+++ b/lib/controllers/verify-email.js
@@ -26,7 +26,7 @@ module.exports = function (req, res, next) {
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
 
-  helpers.handleAcceptRequest(req, {
+  helpers.handleAcceptRequest(req, res, {
     'application/json': function () {
       switch (req.method) {
         case 'POST':

--- a/lib/helpers/handle-accept-request.js
+++ b/lib/helpers/handle-accept-request.js
@@ -10,12 +10,18 @@
  * @param {Object} handlers - Object where the key is the content type to handle.
  * @param {function} fallbackHandler - Handler to call when no content type was matched.
  */
-function handleAcceptRequest(req, handlers, fallbackHandler) {
+function handleAcceptRequest(req, res, handlers, fallbackHandler) {
   var config = req.app.get('stormpathConfig');
   var accepted = req.accepts(config.web.produces);
 
   if (!accepted || !(accepted in handlers)) {
     return fallbackHandler();
+  }
+
+  // If this is a text/html response, then check if we have SPA-mode enabled.
+  // If it is enabled, then return the view for it.
+  if (accepted === 'text/html' && config.web.spa.enabled) {
+    return res.sendFile(config.web.spa.view);
   }
 
   handlers[accepted]();

--- a/lib/helpers/handle-accept-request.js
+++ b/lib/helpers/handle-accept-request.js
@@ -1,14 +1,14 @@
 'use strict';
 
 /**
- * Handles a content type request.
+ * Handles a HTTP Accept request.
  *
  * @method
  * @private
  *
  * @param {Object} req - HTTP request.
- * @param {Object} handlers - Object where the key is the content type to handle.
- * @param {function} fallbackHandler - Handler to call when no content type was matched.
+ * @param {Object} handlers - Object where the key is the content type's available to accept.
+ * @param {function} fallbackHandler - Handler to call when no content type was accepted.
  */
 function handleAcceptRequest(req, res, handlers, fallbackHandler) {
   var config = req.app.get('stormpathConfig');

--- a/lib/helpers/handle-accept-request.js
+++ b/lib/helpers/handle-accept-request.js
@@ -1,12 +1,13 @@
 'use strict';
 
 /**
- * Handles a HTTP Accept request.
+ * Handles an HTTP Accept request.
  *
  * @method
  * @private
  *
  * @param {Object} req - HTTP request.
+ * @param {Object} res - HTTP response.
  * @param {Object} handlers - Object where the key is the content type's available to accept.
  * @param {function} fallbackHandler - Handler to call when no content type was accepted.
  */


### PR DESCRIPTION
Adds support for the web.spa option.

#### Before reviewing

This depends on #313 to be merged before being reviewed.

#### Discuss

What should the default `web.spa.view` value be? I've just set it to `index`, since that is [what the framework spec states](https://github.com/stormpath/stormpath-framework-spec/blob/master/web-config.yaml#L214). But doesn't really make any sense since there won't be any file named `index`.

One solution that I think makes sense would be to set it to `null`, then have a validation step when the configuration is being loaded, to assert that if `web.spa.enabled` is set to `true`, then a value for `web.spa.view` must also be provided.

#### How to verify

1. Checkout this branch.
2. Run `$ npm link`.
3. Checkout the [React example app](https://github.com/stormpath/stormpath-express-react-example).
4. Run `$ npm link express stormpath`.
5. Open up `server.js`.
6. Remove the old `web.spaRoot` option.
7. Set `web.spa.enabled` to `true` and `web.spa.view` to `path.join(__dirname, 'build/index.html')`.
8. Run `$ npm start`.
9. Navigate to [http://locahost:3000/login](http://locahost:3000/login).
10. Verify that the React login view (`build/index.html`) is shown.
11. Open up `server.js`and set `web.spa.enabled` to `false`.
12. Run `$ npm start`.
13. Navigate to [http://locahost:3000/login](http://locahost:3000/login).
14. Verify that the Express Stormpath login view is shown.

Fixes #319.