### PR TITLE
Add produces option for /register

### DIFF
--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -125,7 +125,7 @@ module.exports = function (req, res, next) {
   var postRegistrationHandler = config.postRegistrationHandler;
   var view = config.web.register.view;
 
-  helpers.handleAcceptRequest(req, {
+  helpers.handleAcceptRequest(req, res, {
     'application/json': function () {
       switch (req.method) {
         case 'GET':
@@ -189,17 +189,10 @@ module.exports = function (req, res, next) {
           next();
       }
     },
-    // Handle incoming POST requests from an browser-like clients (something like
-    // chrome / firefox / etc.).
     'text/html': function () {
       switch (req.method) {
         // We should render the registration template.
         case 'GET':
-          if (config.web.spaRoot) {
-            return res.sendFile(config.web.spaRoot);
-          }
-
-          // Render the registration template.
           helpers.render(req, res, view, {
             form: helpers.sanitizeFormData(req.body, config),
             formModel: formModel

--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -114,9 +114,9 @@ function defaultJsonErrorResponder(err, res) {
  *
  * @param {Object} req - The http request.
  * @param {Object} res - The http response.
+ * @param {function} next - The next callback.
  */
-module.exports = function (req, res) {
-  var accepts = req.accepts(['html', 'json']);
+module.exports = function (req, res, next) {
   var application = req.app.get('stormpathApplication');
   var authenticator = new stormpath.OAuthPasswordGrantRequestAuthenticator(application);
   var config = req.app.get('stormpathConfig');
@@ -125,173 +125,185 @@ module.exports = function (req, res) {
   var postRegistrationHandler = config.postRegistrationHandler;
   var view = config.web.register.view;
 
-  // If a GET request is made with the Accept header as json,
-  // respond with the view model for this form.
-  // TODO: When `stormpath.web.produces` is implemented,
-  // this `if` must check that it is set to `application/json`.
-  if (req.method === 'GET' && accepts === 'json') {
-    return helpers.getFormViewModel('register', config, function (err, viewModel) {
-      if (err) {
-        return res.status(400).json({ error: err.userMessage || err.message });
-      }
+  helpers.handleAcceptRequest(req, {
+    'application/json': function () {
+      switch (req.method) {
+        case 'GET':
+          helpers.getFormViewModel('register', config, function (err, viewModel) {
+            if (err) {
+              return res.status(400).json({ error: err.userMessage || err.message });
+            }
 
-      res.status(200).json(viewModel);
-    });
-  }
+            res.status(200).json(viewModel);
+          });
+          break;
 
-  // Handle incoming POST requests from an API-like clients (something like
-  // Angular / React / REST).
-  if (req.method === 'POST' && accepts === 'json') {
-    applyDefaultAccountFields(config, req);
-    helpers.validateAccount(req.body, config, function (errors) {
-      if (errors) {
-        return res.status(400).json({ error: errors[0].message });
-      }
+        case 'POST':
+          applyDefaultAccountFields(config, req);
 
-      helpers.prepAccountData(req.body, config, function (accountData) {
-        application.createAccount(accountData, function (err, account) {
-          if (err) {
-            return defaultJsonErrorResponder(err, res);
-          }
-          helpers.expandAccount(req.app, account, function (err, expandedAccount) {
-            req.user = expandedAccount;
+          helpers.validateAccount(req.body, config, function (errors) {
+            if (errors) {
+              return res.status(400).json({ error: errors[0].message });
+            }
 
-            if (config.web.register.autoLogin) {
-              return authenticator.authenticate({
-                username: req.body.email || uuid(),
-                password: req.body.password || uuid()
-              }, function (err, passwordGrantAuthenticationResult) {
+            helpers.prepAccountData(req.body, config, function (accountData) {
+              application.createAccount(accountData, function (err, account) {
                 if (err) {
                   return defaultJsonErrorResponder(err, res);
                 }
-                helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
-                if (postRegistrationHandler) {
-                  return postRegistrationHandler(expandedAccount, req, res, defaultJsonResponse.bind(null, req, res));
+
+                helpers.expandAccount(req.app, account, function (err, expandedAccount) {
+                  req.user = expandedAccount;
+
+                  if (config.web.register.autoLogin) {
+                    return authenticator.authenticate({
+                      username: req.body.email || uuid(),
+                      password: req.body.password || uuid()
+                    }, function (err, passwordGrantAuthenticationResult) {
+                      if (err) {
+                        return defaultJsonErrorResponder(err, res);
+                      }
+
+                      helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
+
+                      if (postRegistrationHandler) {
+                        return postRegistrationHandler(expandedAccount, req, res, defaultJsonResponse.bind(null, req, res));
+                      }
+
+                      defaultJsonResponse(req, res);
+                    });
+                  }
+
+                  if (postRegistrationHandler) {
+                    return postRegistrationHandler(expandedAccount, req, res, defaultJsonResponse.bind(null, req, res));
+                  }
+
+                  defaultJsonResponse(req, res);
+                });
+              });
+            });
+          });
+          break;
+
+        default:
+          next();
+      }
+    },
+    // Handle incoming POST requests from an browser-like clients (something like
+    // chrome / firefox / etc.).
+    'text/html': function () {
+      switch (req.method) {
+        // We should render the registration template.
+        case 'GET':
+          if (config.web.spaRoot) {
+            return res.sendFile(config.web.spaRoot);
+          }
+
+          // Render the registration template.
+          helpers.render(req, res, view, {
+            form: helpers.sanitizeFormData(req.body, config),
+            formModel: formModel
+          });
+          break;
+
+        // The user is submitting a registration request, so we should attempt
+        // to validate the user's data and create their account.
+        case 'POST':
+          async.waterfall([
+            // What we'll do here is simply set default values for `givenName` and
+            // `surname`, because these value are annoying to set if you don't
+            // care about them.  Eventually Stormpath is going to remove these
+            // required fields, but for now this is a decent workaround to ensure
+            // people don't have to deal with that stuff.
+            function (callback) {
+              applyDefaultAccountFields(config, req);
+              callback();
+            },
+            function (callback) {
+              helpers.validateAccount(req.body, req.app.get('stormpathConfig'), function (errors) {
+                if (errors) {
+                  logger.info(errors);
+                  return helpers.render(req, res, view, {
+                    errors: errors,
+                    form: helpers.sanitizeFormData(req.body, config),
+                    formModel: formModel
+                  });
                 }
-                defaultJsonResponse(req, res);
+
+                callback();
+              });
+            },
+            function (callback) {
+              helpers.prepAccountData(req.body, config, function (accountData) {
+                application.createAccount(accountData, function (err, account) {
+                  if (err) {
+                    logger.info('A user tried to create a new account, but this operation failed with an error message: ' + err.developerMessage);
+                    callback(err);
+                  } else {
+                    res.locals.user = account;
+                    req.user = account;
+                    callback(null, account);
+                  }
+                });
+              });
+            }
+          ], function (err, account) {
+            if (err) {
+              logger.info(err);
+              return helpers.render(req, res, view, {
+                errors: [new Error(err.userMessage)],
+                form: helpers.sanitizeFormData(req.body, config),
+                formModel: formModel
               });
             }
 
-            if (postRegistrationHandler) {
-              return postRegistrationHandler(expandedAccount, req, res, defaultJsonResponse.bind(null, req, res));
-            }
-            defaultJsonResponse(req, res);
-          });
+            // If the account is unverified, we'll show a special message to the
+            // user on the login page.
+            helpers.expandAccount(req.app, account, function (err, expandedAccount) {
+              req.user = expandedAccount;
 
-        });
-      });
-    });
-  // Handle incoming POST requests from an browser-like clients (something like
-  // chrome / firefox / etc.).
-  } else if (accepts === 'html') {
-    if (config.web.spaRoot) {
-      return res.sendFile(config.web.spaRoot);
-    }
+              if (expandedAccount.status === 'UNVERIFIED') {
 
-    // If we get here, it means the user is doing a simple GET request, so we
-    // should just render the registration template.
-    if (req.method === 'GET') {
-      return helpers.render(req, res, view, {
-        form: helpers.sanitizeFormData(req.body, config),
-        formModel: formModel
-      });
-    }
+                if (postRegistrationHandler) {
+                  return postRegistrationHandler(expandedAccount, req, res, defaultUnverifiedHtmlResponse.bind(null, config, res));
+                }
 
-    // If we aren't getting a POST, we should bail quickly.
-    if (req.method !== 'POST') {
-      return res.status(415).end();
-    }
+                return defaultUnverifiedHtmlResponse(config, res);
+              }
 
-    // If we get here, it means the user is submitting a registration request, so
-    // we should attempt to validate the user's data and create their account.
-    async.waterfall([
-      // What we'll do here is simply set default values for `givenName` and
-      // `surname`, because these value are annoying to set if you don't
-      // care about them.  Eventually Stormpath is going to remove these
-      // required fields, but for now this is a decent workaround to ensure
-      // people don't have to deal with that stuff.
-      function (callback) {
-        applyDefaultAccountFields(config, req);
-        callback();
-      },
-      function (callback) {
-        helpers.validateAccount(req.body, req.app.get('stormpathConfig'), function (errors) {
-          if (errors) {
-            logger.info(errors);
-            return helpers.render(req, res, view, {
-              errors: errors,
-              form: helpers.sanitizeFormData(req.body, config),
-              formModel: formModel
+              if (config.web.register.autoLogin) {
+                return authenticator.authenticate({
+                  username: req.body.email || uuid(),
+                  password: req.body.password || uuid()
+                }, function (err, passwordGrantAuthenticationResult) {
+                  if (err) {
+                    return res.status(400).json({ errors: [new Error(err.userMessage || err.message)] });
+                  }
+
+                  helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
+
+                  if (postRegistrationHandler) {
+                    return postRegistrationHandler(expandedAccount, req, res, defaultAutoAuthorizeHtmlResponse.bind(null, config, req, res));
+                  }
+
+                  defaultAutoAuthorizeHtmlResponse(config, req, res);
+                });
+              }
+
+              if (postRegistrationHandler) {
+                return postRegistrationHandler(expandedAccount, req, res, function () {
+                  return defaultCreatedHtmlResponse(config, res);
+                });
+              }
+
+              return defaultCreatedHtmlResponse(config, res);
             });
-          }
-
-          callback();
-        });
-      },
-      function (callback) {
-        helpers.prepAccountData(req.body, config, function (accountData) {
-          application.createAccount(accountData, function (err, account) {
-            if (err) {
-              logger.info('A user tried to create a new account, but this operation failed with an error message: ' + err.developerMessage);
-              callback(err);
-            } else {
-              res.locals.user = account;
-              req.user = account;
-              callback(null, account);
-            }
           });
-        });
+          break;
+
+        default:
+          next();
       }
-    ], function (err, account) {
-      if (err) {
-        logger.info(err);
-        return helpers.render(req, res, view, {
-          errors: [new Error(err.userMessage)],
-          form: helpers.sanitizeFormData(req.body, config),
-          formModel: formModel
-        });
-      }
-      // If the account is unverified, we'll show a special message to the
-      // user on the login page.
-
-      helpers.expandAccount(req.app, account, function (err, expandedAccount) {
-        req.user = expandedAccount;
-
-        if (expandedAccount.status === 'UNVERIFIED') {
-
-          if (postRegistrationHandler) {
-            return postRegistrationHandler(expandedAccount, req, res, defaultUnverifiedHtmlResponse.bind(null, config, res));
-          }
-          return defaultUnverifiedHtmlResponse(config, res);
-        }
-
-        if (config.web.register.autoLogin) {
-          return authenticator.authenticate({
-            username: req.body.email || uuid(),
-            password: req.body.password || uuid()
-          }, function (err, passwordGrantAuthenticationResult) {
-            if (err) {
-              return res.status(400).json({ errors: [new Error(err.userMessage || err.message)] });
-            }
-            helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
-            if (postRegistrationHandler) {
-              return postRegistrationHandler(expandedAccount, req, res, defaultAutoAuthorizeHtmlResponse.bind(null, config, req, res));
-            }
-            defaultAutoAuthorizeHtmlResponse(config, req, res);
-          });
-        }
-
-        if (postRegistrationHandler) {
-          return postRegistrationHandler(expandedAccount, req, res, function () {
-            return defaultCreatedHtmlResponse(config, res);
-          });
-        }
-        return defaultCreatedHtmlResponse(config, res);
-
-
-      });
-    });
-  } else {
-    res.status(415).end();
-  }
+    }
+  }, next);
 };


### PR DESCRIPTION
Implements the produces option for /register according to [the framework spec](https://github.com/stormpath/stormpath-framework-spec/blob/master/registration.md#feature-description).

#### How to verify

1. Checkout this branch.
2. Clone [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project).
3. Use `npm link` and `npm link express-stormpath` to link the library to the example project.
4. Start the server.
5. Navigate to `http://localhost:3000/register`.
6. Sign up for a new account.
7. Open up the terminal and execute `$ http POST localhost:3000/register givenName=test surname=tester email=[your name]+123@stormpath.com password=Test12345_ --json`.
8. Verify that you get a `200 OK` response with the account data as a JSON body.
9. Modify your configuration and change `web.produces` to `['text/html', '']` (hack because extender currently merges arrays... which needs to be fixed, empty string overwrites second array item.).
10. Verify that step 5-6 works, but that step 7 responds with a `404 Not Found` status.
11. Modify the `web.produces` config to `['application/json', '']`.
12. Verify that step 5 results in a `404 Not Found` and that steps 7-8 work as previous.
13. Modify the `web.produces` config again to `['', '']`.
14. Verify that both steps 5 and 7 result in a ´404 Not Found`.

Fixes #309.