### PR TITLE
Add produces option for /forgot

### DIFF
--- a/lib/controllers/change-password.js
+++ b/lib/controllers/change-password.js
@@ -30,19 +30,16 @@ module.exports = function (req, res, next) {
     return res.redirect(config.web.forgotPassword.uri);
   }
 
-  application.verifyPasswordResetToken(sptoken, function (err, result) {
-    if (err) {
-      logger.info('A user attempted to reset their password with a token, but that token verification failed.');
-    }
+  helpers.handleAcceptRequest(req, res, {
+    'application/json': function () {
+      if (req.method !== 'POST') {
+        return next();
+      }
 
-    helpers.handleAcceptRequest(req, res, {
-      'application/json': function () {
+      application.verifyPasswordResetToken(sptoken, function (err, result) {
         if (err) {
+          logger.info('A user attempted to reset their password with a token, but that token verification failed.');
           return res.status(400).json({ error: err.userMessage || err.message });
-        }
-
-        if (req.method !== 'POST') {
-          return next();
         }
 
         result.password = req.body.password;
@@ -55,14 +52,17 @@ module.exports = function (req, res, next) {
 
           res.end();
         });
-      },
-      'text/html': function () {
-        if (err) {
-          return res.redirect(config.web.changePassword.errorUri);
-        }
+      });
+    },
+    'text/html': function () {
+      if (req.method !== 'GET' && req.method !== 'POST') {
+        return next();
+      }
 
-        if (req.method !== 'GET' && req.method !== 'POST') {
-          return next();
+      application.verifyPasswordResetToken(sptoken, function (err, result) {
+        if (err) {
+          logger.info('A user attempted to reset their password with a token, but that token verification failed.');
+          return res.redirect(config.web.changePassword.errorUri);
         }
 
         forms.changePasswordForm.handle(req, {
@@ -106,7 +106,7 @@ module.exports = function (req, res, next) {
             helpers.render(req, res, view, { form: form });
           }
         });
-      }
-    }, next);
-  });
+      });
+    }
+  }, next);
 };

--- a/lib/controllers/change-password.js
+++ b/lib/controllers/change-password.js
@@ -17,9 +17,9 @@ var helpers = require('../helpers');
  *
  * @param {Object} req - The http request.
  * @param {Object} res - The http response.
+ * @param {function} next - Callback to call next middleware.
  */
-module.exports = function (req, res) {
-  var accepts = req.accepts(['html', 'json']);
+module.exports = function (req, res, next) {
   var application = req.app.get('stormpathApplication');
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
@@ -33,66 +33,80 @@ module.exports = function (req, res) {
   application.verifyPasswordResetToken(sptoken, function (err, result) {
     if (err) {
       logger.info('A user attempted to reset their password with a token, but that token verification failed.');
-
-      if (accepts === 'json') {
-        return res.status(400).json({ error: err.userMessage || err.message });
-      }
-
-      return res.redirect(config.web.changePassword.errorUri);
     }
 
-    if (req.method === 'POST' && accepts === 'json') {
-      result.password = req.body.password;
-      return result.save(function (err) {
+    helpers.handleAcceptRequest(req, res, {
+      'application/json': function () {
         if (err) {
-          logger.info('A user attempted to reset their password, but the password change itself failed.');
           return res.status(400).json({ error: err.userMessage || err.message });
         }
 
-        res.end();
-      });
-    }
-
-    forms.changePasswordForm.handle(req, {
-      // If we get here, it means the user is submitting a password change
-      // request, so we should attempt to change the user's password.
-      success: function (form) {
-        if (form.data.password !== form.data.passwordAgain) {
-          return helpers.render(req, res, view, { error: 'Passwords do not match.', form: form });
+        if (req.method !== 'POST') {
+          return;
         }
 
-        result.password = form.data.password;
-        result.save(function (err) {
+        result.password = req.body.password;
+
+        return result.save(function (err) {
           if (err) {
             logger.info('A user attempted to reset their password, but the password change itself failed.');
-            return helpers.render(req, res, view, { error: err.userMessage, form: form });
+            return res.status(400).json({ error: err.userMessage || err.message });
           }
 
-          if (config.web.changePassword.autoLogin) {
-            res.locals.user = result.account;
-            req.user = result.account;
-            return res.redirect(config.web.login.nextUri);
-          }
-
-          res.redirect(config.web.changePassword.nextUri);
+          res.end();
         });
       },
-      // If we get here, it means the user didn't supply required form fields.
-      error: function (form) {
-        // Special case: if the user is being redirected to this page for the
-        // first time, don't display any error.
-        if (form.data && !form.data.password && !form.data.passwordAgain) {
-          return helpers.render(req, res, view, { form: form });
+      'text/html': function () {
+        if (err) {
+          return res.redirect(config.web.changePassword.errorUri);
         }
 
-        var formErrors = helpers.collectFormErrors(form);
-        helpers.render(req, res, view, { form: form, formErrors: formErrors });
-      },
-      // If we get here, it means the user is doing a simple GET request, so we
-      // should just render the forgot password template.
-      empty: function (form) {
-        helpers.render(req, res, view, { form: form });
+        if (req.method !== 'GET' && req.method !== 'POST') {
+          return;
+        }
+
+        forms.changePasswordForm.handle(req, {
+          // If we get here, it means the user is submitting a password change
+          // request, so we should attempt to change the user's password.
+          success: function (form) {
+            if (form.data.password !== form.data.passwordAgain) {
+              return helpers.render(req, res, view, { error: 'Passwords do not match.', form: form });
+            }
+
+            result.password = form.data.password;
+            result.save(function (err) {
+              if (err) {
+                logger.info('A user attempted to reset their password, but the password change itself failed.');
+                return helpers.render(req, res, view, { error: err.userMessage, form: form });
+              }
+
+              if (config.web.changePassword.autoLogin) {
+                res.locals.user = result.account;
+                req.user = result.account;
+                return res.redirect(config.web.login.nextUri);
+              }
+
+              res.redirect(config.web.changePassword.nextUri);
+            });
+          },
+          // If we get here, it means the user didn't supply required form fields.
+          error: function (form) {
+            // Special case: if the user is being redirected to this page for the
+            // first time, don't display any error.
+            if (form.data && !form.data.password && !form.data.passwordAgain) {
+              return helpers.render(req, res, view, { form: form });
+            }
+
+            var formErrors = helpers.collectFormErrors(form);
+            helpers.render(req, res, view, { form: form, formErrors: formErrors });
+          },
+          // If we get here, it means the user is doing a simple GET request, so we
+          // should just render the forgot password template.
+          empty: function (form) {
+            helpers.render(req, res, view, { form: form });
+          }
+        });
       }
-    });
+    }, next);
   });
 };

--- a/lib/controllers/change-password.js
+++ b/lib/controllers/change-password.js
@@ -42,7 +42,7 @@ module.exports = function (req, res, next) {
         }
 
         if (req.method !== 'POST') {
-          return;
+          return next();
         }
 
         result.password = req.body.password;
@@ -62,7 +62,7 @@ module.exports = function (req, res, next) {
         }
 
         if (req.method !== 'GET' && req.method !== 'POST') {
-          return;
+          return next();
         }
 
         forms.changePasswordForm.handle(req, {

--- a/lib/controllers/forgot-password.js
+++ b/lib/controllers/forgot-password.js
@@ -27,7 +27,7 @@ module.exports = function (req, res, next) {
 
   res.locals.status = req.query.status;
 
-  helpers.handleAcceptRequest(req, {
+  helpers.handleAcceptRequest(req, res, {
     // Handle incoming requests from an API-like clients (something like
     // Angular / React / REST).
     'application/json': function () {

--- a/lib/controllers/forgot-password.js
+++ b/lib/controllers/forgot-password.js
@@ -17,9 +17,9 @@ var helpers = require('../helpers');
  *
  * @param {Object} req - The http request.
  * @param {Object} res - The http response.
+ * @param {function} next - The next callback.
  */
-module.exports = function (req, res) {
-  var accepts = req.accepts(['html', 'json']);
+module.exports = function (req, res, next) {
   var application = req.app.get('stormpathApplication');
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
@@ -27,45 +27,58 @@ module.exports = function (req, res) {
 
   res.locals.status = req.query.status;
 
-  if (req.method === 'POST' && accepts === 'json') {
-    return application.sendPasswordResetEmail(req.body.email, function (err) {
-      if (err) {
-        logger.info('A user tried to reset their password, but supplied an invalid email address: ' + req.body.email + '.');
+  helpers.handleAcceptRequest(req, {
+    // Handle incoming requests from an API-like clients (something like
+    // Angular / React / REST).
+    'application/json': function () {
+      if (req.method !== 'POST') {
+        return next();
       }
-      res.end();
-    });
-  }
 
-  if (config.web.spaRoot) {
-    return res.sendFile(config.web.spaRoot);
-  }
-
-  forms.forgotPasswordForm.handle(req, {
-    // If we get here, it means the user is submitting a password reset
-    // request, so we should attempt to send the user a password reset email.
-    success: function (form) {
-      application.sendPasswordResetEmail(form.data.email, function (err) {
+      return application.sendPasswordResetEmail(req.body.email, function (err) {
         if (err) {
-          logger.info('A user tried to reset their password, but supplied an invalid email address: ' + form.data.email + '.');
+          logger.info('A user tried to reset their password, but supplied an invalid email address: ' + req.body.email + '.');
         }
 
-        res.redirect(config.web.forgotPassword.nextUri);
+        res.end();
       });
     },
-    // If we get here, it means the user didn't supply required form fields.
-    error: function (form) {
-      // https://github.com/caolan/forms/issues/96
-      if (req.query.status === 'invalid_sptoken') {
-        return helpers.render(req, res, view, { form: form, status: req.query.status });
+
+    // Handle incoming requests from an browser-like clients (something like
+    // chrome / firefox / etc.).
+    'text/html': function () {
+      if (req.method === 'GET' && config.web.spaRoot) {
+        return res.sendFile(config.web.spaRoot);
       }
 
-      var formErrors = helpers.collectFormErrors(form);
-      helpers.render(req, res, view, { form: form, formErrors: formErrors });
-    },
-    // If we get here, it means the user is doing a simple GET request, so we
-    // should just render the forgot password template.
-    empty: function (form) {
-      helpers.render(req, res, view, { form: form });
+      forms.forgotPasswordForm.handle(req, {
+        // If we get here, it means the user is submitting a password reset
+        // request, so we should attempt to send the user a password reset email.
+        success: function (form) {
+          application.sendPasswordResetEmail(form.data.email, function (err) {
+            if (err) {
+              logger.info('A user tried to reset their password, but supplied an invalid email address: ' + form.data.email + '.');
+            }
+
+            res.redirect(config.web.forgotPassword.nextUri);
+          });
+        },
+        // If we get here, it means the user didn't supply required form fields.
+        error: function (form) {
+          // https://github.com/caolan/forms/issues/96
+          if (req.query.status === 'invalid_sptoken') {
+            return helpers.render(req, res, view, { form: form, status: req.query.status });
+          }
+
+          var formErrors = helpers.collectFormErrors(form);
+          helpers.render(req, res, view, { form: form, formErrors: formErrors });
+        },
+        // If we get here, it means the user is doing a simple GET request, so we
+        // should just render the forgot password template.
+        empty: function (form) {
+          helpers.render(req, res, view, { form: form });
+        }
+      });
     }
-  });
+  }, next);
 };

--- a/lib/controllers/forgot-password.js
+++ b/lib/controllers/forgot-password.js
@@ -28,8 +28,6 @@ module.exports = function (req, res, next) {
   res.locals.status = req.query.status;
 
   helpers.handleAcceptRequest(req, res, {
-    // Handle incoming requests from an API-like clients (something like
-    // Angular / React / REST).
     'application/json': function () {
       if (req.method !== 'POST') {
         return next();
@@ -43,10 +41,11 @@ module.exports = function (req, res, next) {
         res.end();
       });
     },
-
-    // Handle incoming requests from an browser-like clients (something like
-    // chrome / firefox / etc.).
     'text/html': function () {
+      if (req.method !== 'GET' && req.method !== 'POST') {
+        return next();
+      }
+
       forms.forgotPasswordForm.handle(req, {
         // If we get here, it means the user is submitting a password reset
         // request, so we should attempt to send the user a password reset email.

--- a/lib/controllers/forgot-password.js
+++ b/lib/controllers/forgot-password.js
@@ -47,10 +47,6 @@ module.exports = function (req, res, next) {
     // Handle incoming requests from an browser-like clients (something like
     // chrome / firefox / etc.).
     'text/html': function () {
-      if (req.method === 'GET' && config.web.spaRoot) {
-        return res.sendFile(config.web.spaRoot);
-      }
-
       forms.forgotPasswordForm.handle(req, {
         // If we get here, it means the user is submitting a password reset
         // request, so we should attempt to send the user a password reset email.

--- a/test/controllers/test-reset-password.js
+++ b/test/controllers/test-reset-password.js
@@ -349,10 +349,7 @@ describe('resetPassword', function () {
       var app = spaRootFixture.expressApp;
 
       app.on('stormpath.ready', function () {
-        var config = app.get('stormpathConfig');
-        request(app)
-          .get(config.web.changePassword.uri)
-          .set('Accept', 'text/html')
+        requestResetPage(app, passwordResetToken)
           .expect(200)
           .end(spaRootFixture.assertResponse(done));
       });

--- a/test/fixtures/spa-root-fixture.js
+++ b/test/fixtures/spa-root-fixture.js
@@ -24,7 +24,10 @@ function SpaRootFixture(stormpathConfig) {
     stormpathConfig.web = {};
   }
 
-  stormpathConfig.web.spaRoot = this.filename;
+  stormpathConfig.web.spa = {
+    enabled: true,
+    view: this.filename
+  };
 
   this.expressApp = helpers.createStormpathExpressApp(stormpathConfig);
 }


### PR DESCRIPTION
Implements the produces option for `/forgot` according to the framework spec.

#### How to verify

1. Checkout this branch.
2. Clone [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project).
3. Use `npm link` and `npm link express-stormpath` to link the library to the example project.
4. Start the server.
5. Navigate to `http://localhost:3000/forgot`.
6. Submit your email.
7. Open up the terminal and execute `$ http POST localhost:3000/forgot email=[your name]@stormpath.com --json`.
8. Verify that you get a `200 OK` response.
9. Modify your configuration and change `web.produces` to `['text/html', '']` (hack because extender currently merges arrays... which needs to be fixed, empty string overwrites second array item.).
10. Verify that step 5-6 works, but that step 7 responds with a `404 Not Found` status.
11. Modify the `web.produces` config to `['application/json', '']`.
12. Verify that step 5 results in a `404 Not Found` and that steps 7-8 work as previous.
13. Modify the `web.produces` config again to `['', '']`.
14. Verify that both steps 5 and 7 result in a ´404 Not Found`.

Fixes #326.