### PR TITLE
Add produces option for /change

### DIFF
--- a/lib/controllers/change-password.js
+++ b/lib/controllers/change-password.js
@@ -30,19 +30,16 @@ module.exports = function (req, res, next) {
     return res.redirect(config.web.forgotPassword.uri);
   }
 
-  application.verifyPasswordResetToken(sptoken, function (err, result) {
-    if (err) {
-      logger.info('A user attempted to reset their password with a token, but that token verification failed.');
-    }
+  helpers.handleAcceptRequest(req, res, {
+    'application/json': function () {
+      if (req.method !== 'POST') {
+        return next();
+      }
 
-    helpers.handleAcceptRequest(req, res, {
-      'application/json': function () {
+      application.verifyPasswordResetToken(sptoken, function (err, result) {
         if (err) {
+          logger.info('A user attempted to reset their password with a token, but that token verification failed.');
           return res.status(400).json({ error: err.userMessage || err.message });
-        }
-
-        if (req.method !== 'POST') {
-          return next();
         }
 
         result.password = req.body.password;
@@ -55,14 +52,17 @@ module.exports = function (req, res, next) {
 
           res.end();
         });
-      },
-      'text/html': function () {
-        if (err) {
-          return res.redirect(config.web.changePassword.errorUri);
-        }
+      });
+    },
+    'text/html': function () {
+      if (req.method !== 'GET' && req.method !== 'POST') {
+        return next();
+      }
 
-        if (req.method !== 'GET' && req.method !== 'POST') {
-          return next();
+      application.verifyPasswordResetToken(sptoken, function (err, result) {
+        if (err) {
+          logger.info('A user attempted to reset their password with a token, but that token verification failed.');
+          return res.redirect(config.web.changePassword.errorUri);
         }
 
         forms.changePasswordForm.handle(req, {
@@ -106,7 +106,7 @@ module.exports = function (req, res, next) {
             helpers.render(req, res, view, { form: form });
           }
         });
-      }
-    }, next);
-  });
+      });
+    }
+  }, next);
 };

--- a/lib/controllers/change-password.js
+++ b/lib/controllers/change-password.js
@@ -17,9 +17,9 @@ var helpers = require('../helpers');
  *
  * @param {Object} req - The http request.
  * @param {Object} res - The http response.
+ * @param {function} next - Callback to call next middleware.
  */
-module.exports = function (req, res) {
-  var accepts = req.accepts(['html', 'json']);
+module.exports = function (req, res, next) {
   var application = req.app.get('stormpathApplication');
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
@@ -33,66 +33,80 @@ module.exports = function (req, res) {
   application.verifyPasswordResetToken(sptoken, function (err, result) {
     if (err) {
       logger.info('A user attempted to reset their password with a token, but that token verification failed.');
-
-      if (accepts === 'json') {
-        return res.status(400).json({ error: err.userMessage || err.message });
-      }
-
-      return res.redirect(config.web.changePassword.errorUri);
     }
 
-    if (req.method === 'POST' && accepts === 'json') {
-      result.password = req.body.password;
-      return result.save(function (err) {
+    helpers.handleAcceptRequest(req, res, {
+      'application/json': function () {
         if (err) {
-          logger.info('A user attempted to reset their password, but the password change itself failed.');
           return res.status(400).json({ error: err.userMessage || err.message });
         }
 
-        res.end();
-      });
-    }
-
-    forms.changePasswordForm.handle(req, {
-      // If we get here, it means the user is submitting a password change
-      // request, so we should attempt to change the user's password.
-      success: function (form) {
-        if (form.data.password !== form.data.passwordAgain) {
-          return helpers.render(req, res, view, { error: 'Passwords do not match.', form: form });
+        if (req.method !== 'POST') {
+          return;
         }
 
-        result.password = form.data.password;
-        result.save(function (err) {
+        result.password = req.body.password;
+
+        return result.save(function (err) {
           if (err) {
             logger.info('A user attempted to reset their password, but the password change itself failed.');
-            return helpers.render(req, res, view, { error: err.userMessage, form: form });
+            return res.status(400).json({ error: err.userMessage || err.message });
           }
 
-          if (config.web.changePassword.autoLogin) {
-            res.locals.user = result.account;
-            req.user = result.account;
-            return res.redirect(config.web.login.nextUri);
-          }
-
-          res.redirect(config.web.changePassword.nextUri);
+          res.end();
         });
       },
-      // If we get here, it means the user didn't supply required form fields.
-      error: function (form) {
-        // Special case: if the user is being redirected to this page for the
-        // first time, don't display any error.
-        if (form.data && !form.data.password && !form.data.passwordAgain) {
-          return helpers.render(req, res, view, { form: form });
+      'text/html': function () {
+        if (err) {
+          return res.redirect(config.web.changePassword.errorUri);
         }
 
-        var formErrors = helpers.collectFormErrors(form);
-        helpers.render(req, res, view, { form: form, formErrors: formErrors });
-      },
-      // If we get here, it means the user is doing a simple GET request, so we
-      // should just render the forgot password template.
-      empty: function (form) {
-        helpers.render(req, res, view, { form: form });
+        if (req.method !== 'GET' && req.method !== 'POST') {
+          return;
+        }
+
+        forms.changePasswordForm.handle(req, {
+          // If we get here, it means the user is submitting a password change
+          // request, so we should attempt to change the user's password.
+          success: function (form) {
+            if (form.data.password !== form.data.passwordAgain) {
+              return helpers.render(req, res, view, { error: 'Passwords do not match.', form: form });
+            }
+
+            result.password = form.data.password;
+            result.save(function (err) {
+              if (err) {
+                logger.info('A user attempted to reset their password, but the password change itself failed.');
+                return helpers.render(req, res, view, { error: err.userMessage, form: form });
+              }
+
+              if (config.web.changePassword.autoLogin) {
+                res.locals.user = result.account;
+                req.user = result.account;
+                return res.redirect(config.web.login.nextUri);
+              }
+
+              res.redirect(config.web.changePassword.nextUri);
+            });
+          },
+          // If we get here, it means the user didn't supply required form fields.
+          error: function (form) {
+            // Special case: if the user is being redirected to this page for the
+            // first time, don't display any error.
+            if (form.data && !form.data.password && !form.data.passwordAgain) {
+              return helpers.render(req, res, view, { form: form });
+            }
+
+            var formErrors = helpers.collectFormErrors(form);
+            helpers.render(req, res, view, { form: form, formErrors: formErrors });
+          },
+          // If we get here, it means the user is doing a simple GET request, so we
+          // should just render the forgot password template.
+          empty: function (form) {
+            helpers.render(req, res, view, { form: form });
+          }
+        });
       }
-    });
+    }, next);
   });
 };

--- a/lib/controllers/change-password.js
+++ b/lib/controllers/change-password.js
@@ -42,7 +42,7 @@ module.exports = function (req, res, next) {
         }
 
         if (req.method !== 'POST') {
-          return;
+          return next();
         }
 
         result.password = req.body.password;
@@ -62,7 +62,7 @@ module.exports = function (req, res, next) {
         }
 
         if (req.method !== 'GET' && req.method !== 'POST') {
-          return;
+          return next();
         }
 
         forms.changePasswordForm.handle(req, {


### PR DESCRIPTION
Implements the produces option for `/change` according to the framework spec.

### How to verify

1. Checkout this branch
2. Clone [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project)
3. Use `npm link` and `npm link express-stormpath` to link the library to the example project
4. Start the server
5. Verify that you can complete the forgot-password flow (testing especially `/change`)
6. Set `web.produces` to `['text/html', '']`
7. Verify that you still can complete the forgot-password flow
8. Set `web.produces` to `['application/json', '']`
9. Got to <http://localhost:3000/change?sptoken=sdsd> and verify that you get json back
10. Using Postman or another tool, post to <http://localhost:3000/change?sptoken=token> with a real token and `{ "password": "pwd" }`. Also set Accept to `application/json`
11. Verify that you can change your password

Fixes #328.