### PR TITLE
Changes to support the produces option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
   app.use(stormpath.init(app, {
     website: true,
     web: {
-      spaRoot: path.join(__dirname, 'client', 'index.html')
+      spa: {
+        enabled: true,
+        view: path.join(__dirname, 'client', 'index.html')
+      }
     }
   }));
   ```

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -222,14 +222,16 @@ React.  For each feature (login, registration) there is a JSON API for the
 feature.  The JSON API is documented for each feature, please see the feature
 list in the sidebar of this documentation.
 
-In some cases you may need to specify the ``spaRoot`` option.  This
+In some cases you may need to specify the ``spa.view`` option.  This
 is the absolute file path to the entry point for your SPA.  That option
 would be defined like this::
 
     app.use(stormpath.init(app, {
-      website: true,
       web: {
-        spaRoot: path.join(__dirname, 'public', 'index.html')
+        spa: {
+          enabled: true,
+          view: path.join(__dirname, 'public', 'index.html')
+        }
       }
     }));
 

--- a/lib/controllers/login.js
+++ b/lib/controllers/login.js
@@ -102,9 +102,6 @@ module.exports = function (req, res, next) {
       }
     },
     'text/html': function () {
-      if (config.web.spaRoot) {
-        return res.sendFile(config.web.spaRoot);
-      }
 
       var nextUri = url.parse(req.query.next || '').path;
 

--- a/lib/controllers/verify-email.js
+++ b/lib/controllers/verify-email.js
@@ -68,10 +68,6 @@ module.exports = function (req, res, next) {
     'text/html': function () {
       var view = config.web.verifyEmail.view;
 
-      if (config.web.spaRoot) {
-        return res.sendFile(config.web.spaRoot);
-      }
-
       forms.resendAccountVerificationEmailForm.handle(req, {
         // If we get here, it means the user is submitting a request to resend their
         // account verification email, so we should attempt to send the user another

--- a/lib/helpers/handle-accept-request.js
+++ b/lib/helpers/handle-accept-request.js
@@ -1,31 +1,75 @@
 'use strict';
 
+var _ = require('lodash');
+
+var SpaResponseHandler = require('./spa-handler');
+
 /**
- * Handles an HTTP Accept request.
+ * Determines which handler should be used to fulfill a response, given the
+ * Accept header of the request and the content types that are allowed by the
+ * `stormpath.web.produces` configuration.  Also handles the serving of the SPA
+ * root page, if needed.
  *
  * @method
  * @private
  *
  * @param {Object} req - HTTP request.
  * @param {Object} res - HTTP response.
- * @param {Object} handlers - Object where the key is the content type's available to accept.
- * @param {function} fallbackHandler - Handler to call when no content type was accepted.
+ * @param {Object} handlers - Object where the keys are content types and the
+ * functions are handlers that will be called, if needed, to fulfill the
+ * response as that type.
+ * @param {Function} fallbackHandler - Handler to call when an acceptable
+ * content type could not be resolved.
  */
 function handleAcceptRequest(req, res, handlers, fallbackHandler) {
   var config = req.app.get('stormpathConfig');
-  var accepted = req.accepts(config.web.produces);
 
-  if (!accepted || !(accepted in handlers)) {
+  // accepted is an ordered list of preferred types, as specified by the request
+
+  var accepted = req.accepts();
+
+  var produces = config.web.produces;
+
+  /*
+    Our default response is HTML, if the client does not specify something more
+    specific.  As such, map the wildcar type to html.
+  */
+
+  accepted = accepted.map(function (contentType) {
+    return contentType === '*/*' ? 'text/html' : contentType;
+  });
+
+  // Of the accepted types, find the ones that are allowed by the configuration
+
+  var allowedResponseTypes = _.intersection(produces, accepted);
+
+  /*
+    Of the allowed response types, find the first handler that matches.
+
+    But always override with the SPA handler if SPA is enabled.
+  */
+
+  var handler;
+
+  allowedResponseTypes.forEach(function (contentType) {
+    if (handler) {
+      return;
+    }
+
+    if (contentType === 'text/html'  && config.web.spa.enabled) {
+      handler = new SpaResponseHandler(config);
+      return;
+    }
+    handler = handlers[contentType];
+  });
+
+
+
+  if (!handler) {
     return fallbackHandler();
   }
 
-  // If this is a text/html response, then check if we have SPA-mode enabled.
-  // If it is enabled, then return the view for it.
-  if (accepted === 'text/html' && config.web.spa.enabled) {
-    return res.sendFile(config.web.spa.view);
-  }
-
-  handlers[accepted]();
+  handler(req, res);
 }
 
 module.exports = handleAcceptRequest;

--- a/lib/helpers/handle-accept-request.js
+++ b/lib/helpers/handle-accept-request.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
-
-var SpaResponseHandler = require('./spa-handler');
+var spaResponseHandler = require('./spa-response-handler');
 
 /**
  * Determines which handler should be used to fulfill a response, given the
@@ -24,45 +23,34 @@ var SpaResponseHandler = require('./spa-handler');
 function handleAcceptRequest(req, res, handlers, fallbackHandler) {
   var config = req.app.get('stormpathConfig');
 
-  // accepted is an ordered list of preferred types, as specified by the request
-
+  // Accepted is an ordered list of preferred types, as specified by the request.
   var accepted = req.accepts();
-
   var produces = config.web.produces;
 
-  /*
-    Our default response is HTML, if the client does not specify something more
-    specific.  As such, map the wildcard type to html.
-  */
-
+  // Our default response is HTML, if the client does not specify something more
+  // specific.  As such, map the wildcard type to html.
   accepted = accepted.map(function (contentType) {
     return contentType === '*/*' ? 'text/html' : contentType;
   });
 
-  // Of the accepted types, find the ones that are allowed by the configuration
-
+  // Of the accepted types, find the ones that are allowed by the configuration.
   var allowedResponseTypes = _.intersection(produces, accepted);
 
-  /*
-    Of the allowed response types, find the first handler that matches. But
-    always override with the SPA handler if SPA is enabled.
-  */
-
+  // Of the allowed response types, find the first handler that matches. But
+  // always override with the SPA handler if SPA is enabled.
   var handler;
 
-  allowedResponseTypes.forEach(function (contentType) {
-    if (handler) {
-      return;
+  allowedResponseTypes.some(function (contentType) {
+    if (config.web.spa.enabled && contentType === 'text/html') {
+      handler = spaResponseHandler(config);
+      return true;
     }
 
-    if (contentType === 'text/html'  && config.web.spa.enabled) {
-      handler = new SpaResponseHandler(config);
-      return;
+    if (contentType in handlers) {
+      handler = handlers[contentType];
+      return true;
     }
-    handler = handlers[contentType];
   });
-
-
 
   if (!handler) {
     return fallbackHandler();

--- a/lib/helpers/handle-accept-request.js
+++ b/lib/helpers/handle-accept-request.js
@@ -32,7 +32,7 @@ function handleAcceptRequest(req, res, handlers, fallbackHandler) {
 
   /*
     Our default response is HTML, if the client does not specify something more
-    specific.  As such, map the wildcar type to html.
+    specific.  As such, map the wildcard type to html.
   */
 
   accepted = accepted.map(function (contentType) {
@@ -44,9 +44,8 @@ function handleAcceptRequest(req, res, handlers, fallbackHandler) {
   var allowedResponseTypes = _.intersection(produces, accepted);
 
   /*
-    Of the allowed response types, find the first handler that matches.
-
-    But always override with the SPA handler if SPA is enabled.
+    Of the allowed response types, find the first handler that matches. But
+    always override with the SPA handler if SPA is enabled.
   */
 
   var handler;

--- a/lib/helpers/spa-handler.js
+++ b/lib/helpers/spa-handler.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/**
+ * Returns an Express-compatible middleware function that will serve the SPA
+ * root file, as defined by the configuration.
+ *
+ * @param  {Object} stormpathConfig Stormpath config object
+ * @return {Function} spaResponseHandler Middleware function that writes the SPA
+ * response from the configured file.
+ */
+module.exports = function SpaResponseHandler(stormpathConfig) {
+  return function spaResponseHandler(req, res) {
+    res.sendFile(stormpathConfig.web.spa.view);
+  };
+};

--- a/lib/helpers/spa-response-handler.js
+++ b/lib/helpers/spa-response-handler.js
@@ -8,8 +8,8 @@
  * @return {Function} spaResponseHandler Middleware function that writes the SPA
  * response from the configured file.
  */
-module.exports = function SpaResponseHandler(stormpathConfig) {
-  return function spaResponseHandler(req, res) {
+module.exports = function spaResponseHandler(stormpathConfig) {
+  return function spaResponseHandlerMiddleware(req, res) {
     res.sendFile(stormpathConfig.web.spa.view);
   };
 };

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -111,12 +111,6 @@ module.exports.init = function (app, opts) {
       next();
     }
 
-    function addSpaRoute(path) {
-      router.get(path, function (req, res) {
-        res.sendFile(web.spaRoot);
-      });
-    }
-
     function addGetRoute(path, controller) {
       router.get(path, bodyParser.forceDefaultBody(), controller);
     }
@@ -138,11 +132,7 @@ module.exports.init = function (app, opts) {
       if (web.idSite.enabled) {
         addGetRoute(web.register.uri, controllers.idSiteRedirect({ path: web.idSite.registerUri }));
       } else {
-        if (web.spaRoot) {
-          addSpaRoute(web.register.uri);
-        } else {
-          addGetRoute(web.register.uri, controllers.register);
-        }
+        addGetRoute(web.register.uri, controllers.register);
         addPostRoute(web.register.uri, controllers.register, { limit: '11mb' });
       }
     }
@@ -152,11 +142,7 @@ module.exports.init = function (app, opts) {
         addGetRoute(web.login.uri, controllers.idSiteRedirect({ path: web.idSite.loginUri }));
       } else {
         router.use(web.login.uri, stormpathMiddleware);
-        if (web.spaRoot) {
-          addSpaRoute(web.login.uri);
-        } else {
-          addGetRoute(web.login.uri, controllers.login);
-        }
+        addGetRoute(web.login.uri, controllers.login);
         addPostRoute(web.login.uri, controllers.login);
       }
     }
@@ -187,12 +173,7 @@ module.exports.init = function (app, opts) {
     }
 
     if (web.changePassword.enabled) {
-      if (web.spaRoot) {
-        addSpaRoute(web.changePassword.uri);
-      } else {
-        addGetRoute(web.changePassword.uri, controllers.changePassword);
-      }
-
+      addGetRoute(web.changePassword.uri, controllers.changePassword);
       addPostRoute(web.changePassword.uri, controllers.changePassword);
     }
 
@@ -201,7 +182,7 @@ module.exports.init = function (app, opts) {
       addPostRoute(web.verifyEmail.uri, controllers.verifyEmail);
     }
 
-    if (web.spaRoot || web.me.enabled) {
+    if (web.me.enabled) {
       router.get(web.me.uri, stormpathMiddleware, middleware.loginRequired, function (req, res) {
         res.json(req.user);
       });

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "qs": "^6.0.2",
     "request": "^2.63.0",
     "stormpath": "^0.17.1",
-    "stormpath-config": "0.0.18",
+    "stormpath-config": "0.0.19",
     "utils-merge": "^1.0.0",
     "uuid": "^2.0.1",
     "winston": "^2.1.1"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "parse-iso-duration": "^1.0.0",
     "qs": "^6.0.2",
     "request": "^2.63.0",
-    "stormpath": "^0.17.1",
-    "stormpath-config": "0.0.19",
+    "stormpath": "^0.17.2",
+    "stormpath-config": "0.0.20",
     "utils-merge": "^1.0.0",
     "uuid": "^2.0.1",
     "winston": "^2.1.1"

--- a/test/fixtures/produces-fixture.js
+++ b/test/fixtures/produces-fixture.js
@@ -8,8 +8,8 @@ var helpers = require('../helpers');
 
 /**
  * Test fixture for testing the web.produces option.  It requres a Stormpath
- * application an a definition of what content types should be reproduce by
- * the framework instance.
+ * application an a definition of what content types should be produced by the
+ * framework instance.
  *
  * At the moment it is hard-coded to to it's tests against the /login endpoint,
  * that can be changed if we want to test all the endpoints that have content

--- a/test/fixtures/produces-fixture.js
+++ b/test/fixtures/produces-fixture.js
@@ -1,0 +1,73 @@
+'use strict';
+
+var assert = require('assert');
+
+var request = require('supertest');
+
+var helpers = require('../helpers');
+
+/**
+ * Test fixture for testing the web.produces option.  It requres a Stormpath
+ * application an a definition of what content types should be reproduce by
+ * the framework instance.
+ *
+ * At the moment it is hard-coded to to it's tests against the /login endpoint,
+ * that can be changed if we want to test all the endpoints that have content
+ * type negotion, but at this point I don't feel that is necessary.
+ *
+ * @param {Object} stormpathApplication A Stormpath Application Instance
+ * @param {Array} producesArray         The configuration property for web.produces
+ * @param {Function} readyFn            Function that will be called once stormpath.ready has been emitted.
+ */
+function ProducesFixture(stormpathApplication, producesArray, readyFn) {
+  this.expressApp = helpers.createStormpathExpressApp({
+    application: stormpathApplication,
+    website: true,
+    web: {
+      produces: producesArray
+    }
+  });
+  this.expressApp.on('stormpath.ready', readyFn);
+}
+ProducesFixture.prototype.getEndpointWithAccept = function getEndpointWithAccept(acceptString) {
+  var stormpathConfig = this.expressApp.get('stormpathConfig');
+
+  return request(this.expressApp)
+    .get(stormpathConfig.web.login.uri)
+    .set('Accept', acceptString);
+};
+ProducesFixture.prototype.requestAsJson = function requestAsJson() {
+  return this.getEndpointWithAccept('application/json');
+};
+ProducesFixture.prototype.requestAsHtml = function requestAsHtml() {
+  return this.getEndpointWithAccept('text/html');
+};
+ProducesFixture.prototype.assertHtmlResponse = function assertHtmlResponse(done) {
+  return function (err, res) {
+    if (err) {
+      return done(err);
+    }
+    assert.equal(res.headers['content-type'], 'text/html; charset=utf-8');
+    done();
+  };
+};
+ProducesFixture.prototype.assertJsonResponse = function assertJsonResponse(done) {
+  return function (err, res) {
+    if (err) {
+      return done(err);
+    }
+    assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
+    done();
+  };
+};
+ProducesFixture.prototype.assert404Response = function assert404Response(done) {
+  return function (err, res) {
+    if (err) {
+      return done(err);
+    }
+    assert.equal(res.status, 404);
+    done();
+  };
+};
+
+module.exports = ProducesFixture;

--- a/test/produces.js
+++ b/test/produces.js
@@ -1,0 +1,84 @@
+'use strict';
+
+var helpers = require('./helpers');
+
+var ProducesFixture = require('./fixtures/produces-fixture');
+
+describe('produces option', function () {
+
+  var stormpathApplication;
+
+  before(function (done) {
+    helpers.createApplication(helpers.createClient(), function (err, app) {
+      if (err) {
+        return done(err);
+      }
+
+      stormpathApplication = app;
+      done();
+    });
+  });
+
+  after(function (done) {
+    helpers.destroyApplication(stormpathApplication, done);
+  });
+
+  describe('if configured as [\'application/json\',\'text/html\']', function () {
+    var fixture;
+
+    before(function (done) {
+      fixture = new ProducesFixture(stormpathApplication, ['application/json', 'text/html'], done);
+    });
+
+    describe('and request is Accept: text/html', function () {
+      it('should respond with HTML', function (done) {
+        fixture.requestAsHtml().end(fixture.assertHtmlResponse(done));
+      });
+    });
+    describe('and request is Accept: application/json', function () {
+      it('should respond with JSON', function (done) {
+        fixture.requestAsJson().end(fixture.assertJsonResponse(done));
+      });
+    });
+  });
+
+  describe('if configured as [\'application/json\']', function () {
+    var fixture;
+
+    before(function (done) {
+      fixture = new ProducesFixture(stormpathApplication, ['application/json'], done);
+    });
+
+    describe('and request is Accept: text/html', function () {
+      it('should respond with 404', function (done) {
+        fixture.requestAsHtml().end(fixture.assert404Response(done));
+      });
+    });
+
+    describe('and request is Accept: application/json', function () {
+      it('should respond with JSON', function (done) {
+        fixture.requestAsJson().end(fixture.assertJsonResponse(done));
+      });
+    });
+  });
+
+  describe('if configured as [\'text/html\']', function () {
+    var fixture;
+
+    before(function (done) {
+      fixture = new ProducesFixture(stormpathApplication, ['text/html'], done);
+    });
+
+    describe('and request is Accept: text/html', function () {
+      it('should respond with HTML', function (done) {
+        fixture.requestAsHtml().end(fixture.assertHtmlResponse(done));
+      });
+    });
+    describe('and request is Accept: application/json', function () {
+      it('should respond with 404', function (done) {
+        fixture.requestAsJson().end(fixture.assert404Response(done));
+      });
+    });
+  });
+
+});

--- a/test/produces.js
+++ b/test/produces.js
@@ -1,11 +1,9 @@
 'use strict';
 
 var helpers = require('./helpers');
-
 var ProducesFixture = require('./fixtures/produces-fixture');
 
 describe('produces option', function () {
-
   var stormpathApplication;
 
   before(function (done) {


### PR DESCRIPTION
**Description of changes:**

* Determine the correct content type response, based on accept header preferences and produces configuration

* New test suite to assert that the correct content type is being served, given the supplied `stormpath.web.produces` configuration.

* Consolidate SPA serving into a single place.

**Verification**

Run the new tests :) Or checkout the the [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project) and modify the `web.produces` configuration with various options, and assert that you get the correct content types when you change the Accept header for your requests.

**Meta/Discuss**

I'm happy with the new test suite, but not so happy with what's going on inside `handleAcceptRequest`.  Dealing with the SPA serving inside of there isn't right, we should break that out somewhere else.  Doing so will allow us to clean up the content type delegation.  This can be done as a refactor in the future.