### PR TITLE
Don't attach the middleware in stormpath.init()

### DIFF
--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -90,6 +90,12 @@ module.exports.init = function (app, opts) {
     helpers.getUser(req, res, next);
   }
 
+  // This middleware is used for backwards compatibility
+  // when stormpath.init() is wrapped with an app.use().
+  function nopMiddleware(req, res, next) {
+    next();
+  }
+
   // Build routes.
   client.on('ready', function () {
     var config = app.get('stormpathConfig');
@@ -118,11 +124,11 @@ module.exports.init = function (app, opts) {
     }
 
     function addGetRoute(path, controller) {
-      router.get(path, bodyParser.forceDefaultBody(), controller);
+      router.get(path, bodyParser.forceDefaultBody(), stormpathMiddleware, controller);
     }
 
     function addPostRoute(path, controller, options) {
-      router.post(path, bodyParser.formOrJson(options), controller);
+      router.post(path, bodyParser.formOrJson(options), stormpathMiddleware, controller);
     }
 
     router.use(localsMiddleware);
@@ -223,9 +229,8 @@ module.exports.init = function (app, opts) {
 
   app.use(awaitClientReadyMiddleware);
   app.use('/', router);
-  app.use(stormpathMiddleware);
 
-  return stormpathMiddleware;
+  return nopMiddleware;
 };
 
 /**


### PR DESCRIPTION
**WIP - Don't merge, see Discussion!**

Fixes #285.

**Before this fix**, `stormpath.init()` would both attach the middleware and then return it:

```javascript
   app.use(stormpathMiddleware);
 
   return stormpathMiddleware;
 };
```

**With this fix**, `stormpath.init()` returns a `nopMiddleware` which is used for backwards compatibility when `stormpath.init()` is wrapped with an `app.use()`. Then the `stormpathMiddleware` is only attached for the Stormpath specific routes:

```javascript
function addGetRoute(path, controller) {
  router.get(path, bodyParser.forceDefaultBody(), stormpathMiddleware, controller);
}

function addPostRoute(path, controller, options) {
  router.post(path, bodyParser.formOrJson(options), stormpathMiddleware, controller);
}
```

### Discussion

Problem with this is that the menu/navbar stopped working in the example app. The reason is that it need to know whether the user is logged in or not to show the login or the logout button.

```jade
ul.nav.navbar-nav.navbar-right
  if user
    li(class='#{nav.Logout}')
      a(href="/logout") Logout
  else
    li(class='#{nav.Login}')
      a(href='/login') Login
```

One solution would be to manually attaching a new stormpath middleware that would get the user. **An easier solution would be to still return the `stormpathMiddleware` and use `app.use()` on `stormpath.init()`** (that's what the example app does).