### PR TITLE
Add support for the X-Stormpath-Agent header

### DIFF
--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -7,10 +7,11 @@ var winston = require('winston');
 var controllers = require('./controllers');
 var helpers = require('./helpers');
 var middleware = require('./middleware');
-var version = require('../package.json').version;
 var bodyParser = helpers.bodyParser;
 
+var version = require('../package.json').version;
 var expressVersion = helpers.getAppModuleVersion('express') || 'unknown';
+var userAgent = 'stormpath-express/' + version + ' ' + 'express/' + expressVersion;
 
 /**
  * Initialize the Stormpath client.
@@ -24,7 +25,6 @@ var expressVersion = helpers.getAppModuleVersion('express') || 'unknown';
  * @return {Function} A function which accepts a callback.
  */
 function initClient(app, opts) {
-  var userAgent = 'stormpath-express/' + version + ' ' + 'express/' + expressVersion;
   opts.userAgent = userAgent;
 
   var logger = app.get('stormpathLogger');
@@ -74,6 +74,27 @@ module.exports.init = function (app, opts) {
 
   // Indicates whether or not the client is ready.
   var isClientReady = false;
+
+  // Handle the X-Stormpath-Agent header.
+  // Important: This might not report 100% accurately since the
+  // user agent might be overwritten by a subsequent request with a
+  // different header (race condition). But this is "good enough" for
+  // now until we've solved this issue in the Node SDK (since creating
+  // new clients for each request is too expensive it would be
+  // better if we could just scope it).
+  function stormpathUserAgentMiddleware(req, res, next) {
+    var newUserAgent = userAgent;
+    var config = req.app.get('stormpathConfig');
+    var stormpathAgent = req.headers['x-stormpath-agent'];
+
+    if (stormpathAgent) {
+      newUserAgent = stormpathAgent + ' ' + userAgent;
+    }
+
+    config.userAgent = newUserAgent;
+
+    next();
+  }
 
   function awaitClientReadyMiddleware(req, res, next) {
     if (isClientReady) {
@@ -203,6 +224,7 @@ module.exports.init = function (app, opts) {
   });
 
   app.use(awaitClientReadyMiddleware);
+  app.use(stormpathUserAgentMiddleware);
   app.use('/', router);
   app.use(stormpathMiddleware);
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "parse-iso-duration": "^1.0.0",
     "qs": "^6.0.2",
     "request": "^2.63.0",
-    "stormpath": "^0.17.2",
+    "stormpath": "^0.17.4",
     "stormpath-config": "0.0.20",
     "utils-merge": "^1.0.0",
     "uuid": "^2.0.1",


### PR DESCRIPTION
Adds support for the `X-Stormpath-Agent` header.

#### Before review

This depends on https://github.com/stormpath/stormpath-sdk-node/pull/393. So that PR needs to be merged/released and used by this PR before this will function as expected.

#### Discussion

This solution is a bit of a hack. The issue is that we set the `userAgent` when we create our `Node SDK` client. An instance that is only created once and shared among all requests `app.get('stormpathConfig')`. So when we change the `userAgent` config in runtime, it will affect all requests making client API calls. I.e. if the user would host one API and run both Angular and React (which both would send their own `X-Stormpath-Agent` headers, then there's a chance that the requests would overlap and the `User-Agent` header sent would be inconsistent with the request.

##### Possible solutions

* Since this feature is "non-critical", i.e. it does not affect user integration and is only used for us to track which SDK:s are being used. And since the chance of someone running multiple Stormpath integrations to the same API is rather small. Simply just accept the fact that there might be some inconsistencies (**current solution**).
* Create a new but initialized Stormpath client for each request (expensive, but will work).
* Scope the the `Node SDK` client with a config subset, then attach that for each request. E.g. `res.locals.client = client.scope({ userAgent: 'foo/1.2.3' })` (requires some work in the `Node SDK`, but I consider it the best solution).

#### How to verify

1. Checkout this branch.
2. Link it (`$ npm link`).
3. Create a new express test app using [this gist](https://gist.github.com/typerandom/11d2d428e5565ef7a57d).
4. Checkout the `Node SDK` branch for [this PR](https://github.com/stormpath/stormpath-sdk-node/pull/393).
5. Do steps 3-4 of that PR.
6. Link it  (`$ npm link`).
5. Go back to your express branch.
6. Link that to the Node SDK (`$ npm link stormpath`).
7. Go back to your express test app.
8. Link that to this branch (`$ npm link express-stormpath`).
9. Run the test app.
10. Using the Chrome web browser, add [the ModHeader extension](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj).
11. Navigate to `http://localhost:3000/login`.
12. Make a request and check the console.
13. Assert that the regular `User-Agent` header is provided (e.g. `stormpath-express/xxx`).
14. Using the ModHeader extension. Set your own `X-Stormpath-Agent` header.
15. Refresh the `http://localhost:3000/login` page and check the console.
16. Assert that the `User-Agent` header is provided with the `X-Stormpath-Agent` value prepended.

Fixes #338.