### PR TITLE
Change logout endpoint to only respond to POST requests

### DIFF
--- a/docs/logout.rst
+++ b/docs/logout.rst
@@ -8,7 +8,7 @@ If you are using browser-based sessions, you'll need a way for the user to
 logout and destroy their session cookies.
 
 If you've enabled ``{ website: true }`` this library will automatically provide a
-GET route at ``/logout``.  Simply make a request of this URL and the session
+POST route at ``/logout``.  Simply make a request of this URL and the session
 cookies will be destroyed.
 
 

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -181,7 +181,7 @@ module.exports.init = function (app, opts) {
     }
 
     if (web.logout.enabled) {
-      addGetRoute(web.logout.uri, controllers.logout);
+      addPostRoute(web.logout.uri, controllers.logout);
     }
 
     if (web.forgotPassword.enabled) {

--- a/test/controllers/test-logout.js
+++ b/test/controllers/test-logout.js
@@ -34,10 +34,18 @@ describe('logout', function () {
     helpers.destroyApplication(stormpathApplication, done);
   });
 
-  it('should bind to /logout by default', function (done) {
+  it('should not respond to GET request', function (done) {
     var config = app.get('stormpathConfig');
     request(app)
       .get(config.web.logout.uri)
+      .expect(404)
+      .end(done);
+  });
+
+  it('should bind to /logout by default', function (done) {
+    var config = app.get('stormpathConfig');
+    request(app)
+      .post(config.web.logout.uri)
       .expect(302)
       .end(done);
   });
@@ -45,7 +53,7 @@ describe('logout', function () {
   it('should delete the access token and refresh token cookies', function (done) {
     var config = app.get('stormpathConfig');
     request(app)
-      .get(config.web.logout.uri)
+      .post(config.web.logout.uri)
       .expect('Set-Cookie', /access_token=;/)
       .expect('Set-Cookie', /refresh_token=;/)
       .end(done);
@@ -60,7 +68,7 @@ describe('logout', function () {
     it('should respond with 302', function (done) {
       var config = app.get('stormpathConfig');
       request(app)
-        .get(config.web.logout.uri)
+        .post(config.web.logout.uri)
         .set('Accept', 'text/html')
         .expect(302)
         .end(done);
@@ -71,7 +79,7 @@ describe('logout', function () {
     it('should respond with 200', function (done) {
       var config = app.get('stormpathConfig');
       request(app)
-        .get(config.web.logout.uri)
+        .post(config.web.logout.uri)
         .set('Accept', 'application/json')
         .expect(200)
         .end(done);
@@ -81,7 +89,7 @@ describe('logout', function () {
   it('should follow the next param if present', function (done) {
     var config = app.get('stormpathConfig');
     request(app)
-      .get(config.web.logout.uri + '?next=/goodbye')
+      .post(config.web.logout.uri + '?next=/goodbye')
       .expect(302)
       .expect('Location', '/goodbye')
       .end(done);


### PR DESCRIPTION
Changes the `/logout` endpoint to only respond to POST requests.

#### How to verify

1. Checkout this branch.
2. Link it (`$ npm link`).
3. Create a new test application using [this gist](https://gist.github.com/typerandom/587ea241ec04eb2152af).
4. Link to our branch (`$ npm link express-stormpath`).
5. Start the application.
6. Navigate to `/logout`.
7. Verify that you get a `HTTP 404` response.
8. Navigate to `/login`.
9. Login as an existing user.
10. You should now be seeing a `Logout` button.
11. Press the `Logout` button and verify that you're no longer logged in.

Fixes #352.