### PR TITLE
Registration login updates

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -24,13 +24,17 @@ before release:
   - OAuth2 endpoint
   - ``/me`` endpoint
 
-- ``web.regisgter.fields`` -> ``web.register.form.fields``
+- ``web.register.fields`` -> ``web.register.form.fields``
 
-- ``web.regisgter.fieldOrder`` -> ``web.register.form.fieldOrder``
+- ``web.register.fieldOrder`` -> ``web.register.form.fieldOrder``
 
 - ``web.expand[property]`` options won't affect the ``/me`` route anymore.  To
   enable expansions on the `/me` route, use ``web.me.expand[property]``
 
+- The JSON response for the register route is now wrapping the account data in
+  ``{ account: { /* account data */ } }``.  Previously it was not wrapped inside
+  this account property.  Linked resources have also been stripped from the
+  response, for security purposes.
 
 Version 2.3.7 -> Version 2.4.0
 ------------------------------

--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -66,7 +66,7 @@ function defaultAutoAuthorizeHtmlResponse(config, req, res) {
  * @param {Object} res - The http response.
  */
 function defaultJsonResponse(req, res) {
-  res.json(req.user);
+  helpers.strippedAccountResponse(req.user, res);
 }
 
 /**

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -22,5 +22,6 @@ module.exports = {
   validateAccount: require('./validate-account'),
   xsrfValidator: require('./xsrf-validator'),
   revokeToken: require('./revoke-token'),
-  getFormViewModel: require('./get-form-view-model').default
+  getFormViewModel: require('./get-form-view-model').default,
+  strippedAccountResponse: require('./stripped-account-response')
 };

--- a/lib/helpers/login-responder.js
+++ b/lib/helpers/login-responder.js
@@ -2,6 +2,7 @@
 
 var createSession = require('./create-session');
 var expandAccount = require('./expand-account');
+var strippedAccountResponse = require('./stripped-account-response');
 var url = require('url');
 
 /**
@@ -19,7 +20,7 @@ function loginResponse(req, res) {
   var nextUrl = url.parse(req.query.next || '').path || config.web.login.nextUri;
 
   if (accepts === 'json') {
-    return res.end();
+    return strippedAccountResponse(req.user, res);
   }
 
   res.redirect(302, nextUrl);

--- a/lib/helpers/stripped-account-response.js
+++ b/lib/helpers/stripped-account-response.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var _ = require('lodash');
+
+/**
+ * Respond with an account object, but strips all of the linked resources.
+ *
+ * @function
+ *
+ * @param {Object} account - The stormpath account object.
+ * @param {Object} req - The http request.
+ */
+function strippedAccountResponse(account, res) {
+  var strippedAccount = _.clone(account);
+  Object.keys(strippedAccount).forEach(function (property) {
+    if (strippedAccount[property] && strippedAccount[property].href) {
+      delete strippedAccount[property];
+    }
+  });
+  res.json({
+    account: strippedAccount
+  });
+}
+
+module.exports = strippedAccountResponse;

--- a/test/controllers/test-login.js
+++ b/test/controllers/test-login.js
@@ -128,6 +128,7 @@ describe('login', function () {
           assert.equal(res.body.account.email, accountData.email);
           // But linked resources should not be returned
           assert.equal(res.body.account.customDta, undefined);
+          done();
         });
     });
   });

--- a/test/controllers/test-login.js
+++ b/test/controllers/test-login.js
@@ -120,7 +120,15 @@ describe('login', function () {
         .send({ username: username, password: password })
         .set('Accept', 'application/json')
         .expect(200)
-        .end(done);
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          // The account data should be returned on the account object
+          assert.equal(res.body.account.email, accountData.email);
+          // But linked resources should not be returned
+          assert.equal(res.body.account.customDta, undefined);
+        });
     });
   });
 

--- a/test/controllers/test-register.js
+++ b/test/controllers/test-register.js
@@ -437,6 +437,38 @@ describe('register', function () {
         });
 
     });
+
+    describe('with Accept: application/json requests', function () {
+      it('should create an account if the data is valid, and not expose the email verification token', function (done) {
+
+        var formData = defaultRegistrationFixture.defaultFormPost();
+
+        request(defaultRegistrationFixture.expressApp)
+          .post('/register')
+          .set('Accept', 'application/json')
+          .type('json')
+          .send(formData)
+          .expect(200)
+          .end(function (err, res) {
+            if (err) {
+              return done(err);
+            }
+
+            var json = JSON.parse(res.text);
+
+            assert(json.account.href);
+            assert.equal(json.account.givenName, formData.givenName);
+            assert.equal(json.account.surname, formData.surname);
+            assert.equal(json.account.email, formData.email);
+            assert.equal(json.account.emailVerificationToken, undefined);
+
+            done();
+          });
+
+      });
+    });
+
+    // it should do json the right way
   });
 
   describe('with Accept: application/json requests', function () {
@@ -491,10 +523,10 @@ describe('register', function () {
 
             var json = JSON.parse(res.text);
 
-            assert(json.href);
-            assert.equal(json.givenName, formData.givenName);
-            assert.equal(json.surname, formData.surname);
-            assert.equal(json.email, formData.email);
+            assert(json.account.href);
+            assert.equal(json.account.givenName, formData.givenName);
+            assert.equal(json.account.surname, formData.surname);
+            assert.equal(json.account.email, formData.email);
 
             done();
           });
@@ -556,9 +588,9 @@ describe('register', function () {
               return done(err);
             }
 
-            assert.equal(res.body.givenName, 'UNKNOWN');
-            assert.equal(res.body.surname, 'UNKNOWN');
-            assert.equal(res.body.email, formData.email);
+            assert.equal(res.body.account.givenName, 'UNKNOWN');
+            assert.equal(res.body.account.surname, 'UNKNOWN');
+            assert.equal(res.body.account.email, formData.email);
             done();
           });
 
@@ -583,9 +615,9 @@ describe('register', function () {
               return done(err);
             }
 
-            assert.equal(res.body.givenName, 'UNKNOWN');
-            assert.equal(res.body.surname, 'UNKNOWN');
-            assert.equal(res.body.email, formData.email);
+            assert.equal(res.body.account.givenName, 'UNKNOWN');
+            assert.equal(res.body.account.surname, 'UNKNOWN');
+            assert.equal(res.body.account.email, formData.email);
             done();
           });
       });


### PR DESCRIPTION
* Don’t expose linked resources

* Wrap account data in the `account` object key.