### PR TITLE
getUser changes, stormpath.ready event changes

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -36,6 +36,15 @@ before release:
   this account property.  Linked resources have also been stripped from the
   response, for security purposes.
 
+- We've stopped resolving the user by default, for un-authenticated routes.  If
+  you have a route that does not require authentication, but you want to know
+  the context of the current user (if they're logged in), then add the
+  ``stormpath.getUser`` middleware to the route.
+
+- You no longer need to wait for ``stormpath.ready`` to start your serer.  If
+  the server is waiting on Stormpath to initialize, it will hold the request
+  until Stormpath is ready.
+
 Version 2.3.7 -> Version 2.4.0
 ------------------------------
 

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -100,8 +100,7 @@ module.exports.init = function (app, opts) {
     if (isClientReady) {
       next();
     } else {
-      client.on('ready', function () {
-        isClientReady = true;
+      app.on('stormpath.ready', function () {
         next();
       });
     }
@@ -110,6 +109,8 @@ module.exports.init = function (app, opts) {
   function stormpathMiddleware(req, res, next) {
     helpers.getUser(req, res, next);
   }
+
+
 
   // Build routes.
   client.on('ready', function () {
@@ -162,7 +163,7 @@ module.exports.init = function (app, opts) {
       if (web.idSite.enabled) {
         addGetRoute(web.login.uri, controllers.idSiteRedirect({ path: web.idSite.loginUri }));
       } else {
-        router.use(web.login.uri, stormpathMiddleware);
+        router.use(web.login.uri, helpers.getUser);
         addGetRoute(web.login.uri, controllers.login);
         addPostRoute(web.login.uri, controllers.login);
       }
@@ -217,31 +218,42 @@ module.exports.init = function (app, opts) {
       }
 
       app.set('stormpathApplication', application);
+      isClientReady = true;
       app.emit('stormpath.ready');
     });
   });
 
-  app.use(awaitClientReadyMiddleware);
-  app.use(stormpathUserAgentMiddleware);
-  app.use('/', router);
-  app.use(stormpathMiddleware);
+  router.use(stormpathUserAgentMiddleware);
 
-  return stormpathMiddleware;
+  app.use(awaitClientReadyMiddleware);
+
+  return router;
 };
+
+function getUserMiddlewareProxy(nextMiddleware) {
+  return function (req, res, next) {
+    helpers.getUser(req, res, nextMiddleware.bind(null, req, res, next));
+  };
+}
 
 /**
  * Expose the `loginRequired` middleware.
  *
  * @property loginRequired
  */
-module.exports.loginRequired = middleware.loginRequired;
+module.exports.loginRequired = getUserMiddlewareProxy(middleware.loginRequired);
+
+module.exports.getUser = helpers.getUser;
 
 /**
  * Expose the `groupsRequired` middleware.
  *
  * @property groupsRequired
  */
-module.exports.groupsRequired = middleware.groupsRequired;
+module.exports.groupsRequired = function groupsRequiredProxy() {
+  return getUserMiddlewareProxy(middleware.groupsRequired.apply(null, arguments));
+};
+
 
 /**
  * Expose the `apiAuthenticationRequired` middleware.
@@ -255,4 +267,4 @@ module.exports.apiAuthenticationRequired = middleware.apiAuthenticationRequired;
  *
  * @property authenticationRequired
  */
-module.exports.authenticationRequired = middleware.authenticationRequired;
+module.exports.authenticationRequired = getUserMiddlewareProxy(middleware.authenticationRequired);


### PR DESCRIPTION
* Don’t use getUser for un-authenticated routes, that is now opt-in

* Hold requests until stormpath is ready, so that the developer no longer needs to wait on the `stormpath.ready` event.

Closes #285 