### PR TITLE
Fix cookies for social login

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -32,7 +32,7 @@ web:
     secure: null
 
     # Controls the path flag of the cookie.  Inherits from basePath, but can be
-    # over-ridden here.
+    # overridden here.
     path: null
 
     # Controls the domain flag on the cookie, will not be set unless specified.

--- a/lib/config.yml
+++ b/lib/config.yml
@@ -1,5 +1,7 @@
 web:
-  ## basePath is currently not used by Express-Stormpath
+
+  # The basePath is used as the default path for the cookies that are set by
+  # this library.  If not defined, we will default to /
   basePath: null
 
   oauth2:
@@ -14,21 +16,32 @@ web:
       validationStrategy: "local"
 
   accessTokenCookie:
+
+    # Controls the name of the cookie that we send to the browser.
     name: "access_token"
+
+    # httpOnly is true, to prevent XSS attacks from hijacking your cookies.  We
+    # highly recommend that you do not change this.
     httpOnly: true
 
-    # See cookie-authentication.md for explanation of
-    # how `null` values behave for these properties.
+    # The secure property controls the Secure flag on the cookie.  The
+    # framework will auto-detect if the incoming request is over HTTPS, by
+    # looking at req.protocol === 'https' and turn on Secure if so.  You can
+    # override auto-detection and force the Secure flag on by setting this
+    # property to true, or force off by setting this property to false.
     secure: null
+
+    # Controls the path flag of the cookie.  Inherits from basePath, but can be
+    # over-ridden here.
     path: null
+
+    # Controls the domain flag on the cookie, will not be set unless specified.
     domain: null
 
+  # Refresh Token Cookie has same options as the Access Token Cookie (above).
   refreshTokenCookie:
     name: "refresh_token"
     httpOnly: true
-
-    # See cookie-authentication.md for explanation of
-    # how `null` values behave for these properties.
     secure: null
     path: null
     domain: null

--- a/lib/helpers/create-session.js
+++ b/lib/helpers/create-session.js
@@ -24,7 +24,7 @@ module.exports = function (authenticationResult, account, req, res) {
       domain: cookieConfig.domain,
       expires: new Date(token.body.exp * 1000),
       httpOnly: cookieConfig.httpOnly,
-      path: cookieConfig.path,
+      path: cookieConfig.path || '/',
       secure: cookieConfig.secure === null ? isSecureRequest : cookieConfig.secure
     });
   }


### PR DESCRIPTION
During the yaml upgrades, we forgot to default the cookie path to / if not specified.  This is required because if we omit the path, the cookies will be set on the /callback URI when social login happens, and those cookies are then trapped on that URL and can’t be used on the rest of the site.

I’ve added a test case in the login controller test, to assert that we set the cookies with the default path of /

I’ve also refactored that test file to create two express apps fixtures in the begin block, which is must faster than creating one at every block.  This is a test change that I’ve been implementing in most of my PRs.

I’ve added some clarifying comments to the yaml file, about cookies. Ideally we would have some actual IT tests to assert social callbacks, but this new test will work for now because we have a common method for creating our cookies.

Once merged I’ll release this at 3.0.1