### PR TITLE
Fix LinkedIn login

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -203,7 +203,7 @@ web:
       scope: "email profile"
     linkedin:
       uri: "/callbacks/linkedin"
-      scope: "r_basicprofile, r_emailaddress"
+      scope: "r_basicprofile r_emailaddress"
 
   # The /me route is for front-end applications, it returns a JSON object with
   # the current user object.  The developer can opt-in to expanding account

--- a/lib/controllers/index.js
+++ b/lib/controllers/index.js
@@ -9,7 +9,7 @@ module.exports = {
   googleLogin: require('./google-login'),
   idSiteRedirect: require('./id-site-redirect'),
   idSiteVerify: require('./id-site-verify'),
-  linkedInLogin: require('./linkedin-login'),
+  linkedinLogin: require('./linkedin-login'),
   githubLogin: require('./github-login'),
   login: require('./login'),
   logout: require('./logout'),

--- a/lib/controllers/linkedin-login.js
+++ b/lib/controllers/linkedin-login.js
@@ -42,6 +42,11 @@ module.exports = function (req, res) {
   }
 
   oauth.linkedIn.exchangeAuthCodeForAccessToken(req, config, function (err, accessToken) {
+    if (err) {
+      logger.info('During a LinkedIn OAuth login attempt, we were unable to exchange the auth code for an access token.');
+      return oauth.errorResponder(req, res, err);
+    }
+
     var userData = {
       providerData: {
         accessToken: accessToken,

--- a/lib/oauth/linkedin.js
+++ b/lib/oauth/linkedin.js
@@ -40,6 +40,21 @@ module.exports = {
         return callback(err);
       }
 
+      if (parsedBody.error) {
+        var errorMessage;
+
+        switch (parsedBody.error) {
+          case 'unauthorized_client':
+            errorMessage = 'Unable to authenticate with LinkedIn. Please verify that your configuration is correct.';
+            break;
+
+          default:
+            errorMessage = 'LinkedIn error when exchanging auth code for access token: ' + parsedBody.error_description + ' (' + parsedBody.error + ')';
+        }
+
+        return callback(new Error(errorMessage));
+      }
+
       callback(err, parsedBody.access_token);
     });
   }


### PR DESCRIPTION
This PR fixes a couple of issues that made LinkedIn login not work.

* 9bdf86f – Renamed `linkedInLogin` controller to `linkedinLogin`, otherwise it would not be found at all
* 7bf9c2a – Changed default LinkedIn scopes to be space delimited instead of comma delimited

Fixes #305.

### How to verify

1. Checkout this branch
2. Checkout [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project)
2. Configure a Directory with LinkedIn
3. Run the example (linked to `express-stormpath` ofc).
4. Verify that LinkedIn login works without errors
