### PR TITLE
pre-warm view model cache for faster SPA applications

### DIFF
--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -213,6 +213,10 @@ module.exports.init = function (app, opts) {
         throw new Error('Cannot fetch application ' + config.application.href);
       }
 
+      // Warm the view model cache
+      helpers.getFormViewModel('login', config, function () {});
+      helpers.getFormViewModel('register', config, function () {});
+
       app.set('stormpathApplication', application);
       isClientReady = true;
       app.emit('stormpath.ready');


### PR DESCRIPTION
Quick change to get these cached warmed, so that you're not waiting on them when you load your Angular application for the first time.  Not a huge fan of the anon callbacks, can refactor later if desireed.