### PR TITLE
Validate the hosted domain parameter (hd) when used on the initial oa…

### DIFF
--- a/lib/controllers/google-login.js
+++ b/lib/controllers/google-login.js
@@ -30,6 +30,14 @@ module.exports = function (req, res) {
   var logger = req.app.get('stormpathLogger');
   var loginHandler = config.postLoginHandler;
   var registrationHandler = config.postRegistrationHandler;
+  var socialProviders = config.socialProviders;
+
+  if (socialProviders.google.hd) {
+    if (!req.query.hd || req.query.hd != socialProviders.google.hd) {
+      logger.info('A user attempted to log in via Google OAuth using an invalid hosted domain.');
+      return res.status(400).json({ message: 'invalid hosted domain parameter.' });
+    }
+  }
 
   if (!req.query.code) {
     logger.info('A user attempted to log in via Google OAuth without specifying an OAuth token.');


### PR DESCRIPTION
Validate the hosted domain parameter (hd) when used on the initial oauth uri.

Just specifying hd=yourdomain.com is not enough to ensure only your domain
authenticates.

Google returns the authenticated hosted domain as a query parameter on the
callbackURI.  This value must match the hd value intially supplied or its a
waste of time and any domain may authenticate.

See also: https://developers.google.com/identity/protocols/OpenIDConnect#hd-param

To test this, use something like:
```
app.use(stormpath.init(app, {
    ...
    socialProviders: {
        google: {
            hd: "yourdomain.com",
            callbackUri: "/your/callback"
        }
    }
}));
```

in your main express app.js file.