### PR TITLE
Add Facebook authorization code support

### DIFF
--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -33,56 +33,76 @@ module.exports = function (req, res) {
   var application = req.app.get('stormpathApplication');
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
+
   var loginHandler = config.postLoginHandler;
   var registrationHandler = config.postRegistrationHandler;
 
-  if (!req.query.access_token) {
-    logger.info('A user attempted to log in via Facebook OAuth without specifying an OAuth token.');
-    return oauth.errorResponder(req, res, new Error('access_token parameter required.'));
-  }
+  var provider = config.web.social.facebook;
+  var baseUrl = req.protocol + '://' + req.get('host');
+  var authUrl = 'https://graph.facebook.com/oauth/access_token';
 
-  var userData = {
-    providerData: {
-      accessToken: req.query.access_token,
-      providerId: 'facebook'
-    }
-  };
-
-  application.getAccount(userData, function (err, resp) {
-    if (err) {
-      logger.info('During a Facebook OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
-      return oauth.errorResponder(req, res, err);
+  function loginWithAccessToken(accessToken) {
+    if (!accessToken) {
+      logger.info('A user attempted to log in via Facebook OAuth without specifying an OAuth token.');
+      return oauth.errorResponder(req, res, new Error('Access token parameter required.'));
     }
 
-    helpers.expandAccount(resp.account, config.expand, logger, function (err, expandedAccount) {
+    var userData = {
+      providerData: {
+        accessToken: accessToken,
+        providerId: 'facebook'
+      }
+    };
+
+    application.getAccount(userData, function (err, resp) {
       if (err) {
         logger.info('During a Facebook OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
         return oauth.errorResponder(req, res, err);
       }
 
-      res.locals.user = expandedAccount;
-      req.user = expandedAccount;
-
-      helpers.createStormpathSession(req.user, req, res, function (err) {
+      helpers.expandAccount(resp.account, config.expand, logger, function (err, expandedAccount) {
         if (err) {
-          logger.info('During a Facebook OAuth login attempt, we were unable to create a Stormpath session.');
+          logger.info('During a Facebook OAuth login attempt, we were unable to fetch the user\'s social account from Stormpath.');
           return oauth.errorResponder(req, res, err);
         }
 
-        var nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+        res.locals.user = expandedAccount;
+        req.user = expandedAccount;
 
-        if (resp.created && registrationHandler) {
-          registrationHandler(req.user, req, res, function () {
+        helpers.createStormpathSession(req.user, req, res, function (err) {
+          if (err) {
+            logger.info('During a Facebook OAuth login attempt, we were unable to create a Stormpath session.');
+            return oauth.errorResponder(req, res, err);
+          }
+
+          var nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+
+          if (resp.created && registrationHandler) {
+            registrationHandler(req.user, req, res, function () {
+              res.redirect(302, nextUrl);
+            });
+          } else if (loginHandler) {
+            loginHandler(req.user, req, res, function () {
+              res.redirect(302, nextUrl);
+            });
+          } else {
             res.redirect(302, nextUrl);
-          });
-        } else if (loginHandler) {
-          loginHandler(req.user, req, res, function () {
-            res.redirect(302, nextUrl);
-          });
-        } else {
-          res.redirect(302, nextUrl);
-        }
+          }
+        });
       });
     });
-  });
+  }
+
+  if (req.query.code) {
+    oauth.common.exchangeAuthCodeForAccessToken(authUrl, req.query.code, req.cookies.oauthStateToken, baseUrl, provider, function (err, accessToken) {
+      if (err) {
+        logger.info('During a Facebook OAuth login attempt, we were unable to exchange the authentication code for an access token.');
+        return oauth.errorResponder(req, res, err);
+      }
+
+      loginWithAccessToken(accessToken);
+    });
+  } else if (req.query.access_token) {
+    loginWithAccessToken(req.query.access_token);
+  }
 };

--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -38,8 +38,8 @@ module.exports = function (req, res) {
   var registrationHandler = config.postRegistrationHandler;
 
   var provider = config.web.social.facebook;
-  var baseUrl = req.protocol + '://' + req.get('host');
   var authUrl = 'https://graph.facebook.com/oauth/access_token';
+  var baseUrl = config.web.baseUrl || req.protocol + '://' + req.get('host');
 
   function loginWithAccessToken(accessToken) {
     if (!accessToken) {

--- a/lib/controllers/github-login.js
+++ b/lib/controllers/github-login.js
@@ -28,7 +28,7 @@ module.exports = function (req, res) {
   var loginHandler = config.postLoginHandler;
   var registrationHandler = config.postRegistrationHandler;
   var provider = config.web.social.github;
-  var baseUrl = req.protocol + '://' + req.get('host');
+  var baseUrl = config.web.baseUrl || req.protocol + '://' + req.get('host');
   var authUrl = 'https://github.com/login/oauth/access_token';
   var code = req.query.code;
 

--- a/lib/oauth/common.js
+++ b/lib/oauth/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var uuid = require('uuid');
+var qs = require('querystring');
 var request = require('request');
 
 var setTempCookie = require('../helpers/set-temp-cookie');
@@ -103,17 +104,31 @@ module.exports = {
     request.post(authUrl, options, function (err, result, body) {
       var parsedBody;
 
-      try {
-        parsedBody = JSON.parse(body);
-      } catch (err) {
+      if (err) {
         return callback(err);
       }
 
-      if (parsedBody.error) {
-        return callback(new Error(parsedBody.error));
+      var contentType = result.headers['content-type'] || '';
+
+      if (contentType.indexOf('text/plain') === 0) {
+        parsedBody = qs.parse(body);
+      } else {
+        try {
+          parsedBody = JSON.parse(body);
+        } catch (err) {
+          return callback(err);
+        }
+
+        if (parsedBody.error) {
+          return callback(new Error(parsedBody.error));
+        }
       }
 
-      callback(err, parsedBody.access_token);
+      if (!parsedBody || typeof parsedBody !== 'object' || !parsedBody.access_token) {
+        return callback(new Error('Unable to parse response when exchanging an authorization code for an access token.'));
+      }
+
+      callback(null, parsedBody.access_token);
     });
   }
 };


### PR DESCRIPTION
Add support for exchanging a Facebook authorization code for an access token.

#### How to verify

1. Log into the Stormpath Console and map a Facebook directory to your application.
2. Checkout [the Angular JS example project](https://github.com/stormpath/stormpath-sdk-angularjs/tree/master/example/dashboard-app). Run it and verify that you can login with Facebook. This tests authentication with an access token.
3. Go to [this React SDK PR](https://github.com/stormpath/stormpath-sdk-react/pull/46). Do steps 1-8 and step 10 (but only for the Facebook provider). This tests authentication with an authorization code.
