### PR TITLE
Add support for preRegistrationHandler and preLoginHandler

### DIFF
--- a/docs/login.rst
+++ b/docs/login.rst
@@ -117,6 +117,50 @@ has a default login form, and a mapped Google directory:
     }
   }
 
+.. _pre_login_handler:
+
+Pre Login Handler
+-----------------
+
+Want to validate the form before it's handled, then this is the event
+that you want to handle!
+
+To use a ``preLoginHandler`` you need to define your handler function
+in the Stormpath config::
+
+    app.use(stormpath.init(app, {
+      preLoginHandler: function (formData, req, res, next) {
+        console.log('Got login request', formData);
+        next();
+      }
+    }));
+
+As you can see in the example above, the ``preLoginHandler`` function
+takes in four parameters:
+
+- ``formData``: The data submitted in the form.
+- ``req``: The Express request object.  This can be used to modify the incoming
+  request directly.
+- ``res``: The Express response object.  This can be used to modify the HTTP
+  response directly.
+- ``next``: The callback to call when you either want to return an error, or
+  want the login to continue processing. I.e. if you call this callback
+  with an error then the form will stop on that. But if you call it without
+  any arguments, then the form will just continue processing like normally.
+
+In the example below, we'll use the ``preLoginHandler`` to validate that
+the user doesn't enter an email domain that is restricted::
+
+    app.use(stormpath.init(app, {
+      preLoginHandler: function (formData, req, res, next) {
+        if (formData.email.indexOf('@some-domain.com') !== -1) {
+          return next(new Error('You\'re not allowed to login with \'@some-domain.com\'.'));
+        }
+
+        next();
+      }
+    }));
+
 .. _post_login_handler:
 
 Post Login Handler
@@ -136,7 +180,7 @@ in the Stormpath config::
       postLoginHandler: function (account, req, res, next) {
         console.log('User:', account.email, 'just logged in!');
         next();
-      },
+      }
     }));
 
 As you can see in the example above, the ``postLoginHandler`` function
@@ -157,9 +201,8 @@ user to a special page (*instead of the normal login flow*)::
     app.use(stormpath.init(app, {
       postLoginHandler: function (account, req, res, next) {
         res.redirect(302, '/secretpage').end();
-      },
+      }
     }));
-
 
 Using ID Site
 -------------
@@ -180,7 +223,6 @@ For more information about how to use and customize the ID site, please see
 this documentation:
 
 http://docs.stormpath.com/guides/using-id-site/
-
 
 ID Site Configuration
 .....................

--- a/docs/login.rst
+++ b/docs/login.rst
@@ -122,11 +122,11 @@ has a default login form, and a mapped Google directory:
 Pre Login Handler
 -----------------
 
-Want to validate the form before it's handled, then this is the event
-that you want to handle!
+Want to validate or modify the form data before it's handled by us? Then this is
+the handler that you want to use!
 
-To use a ``preLoginHandler`` you need to define your handler function
-in the Stormpath config::
+To use a ``preLoginHandler`` you need to define your handler function in the
+Stormpath config::
 
     app.use(stormpath.init(app, {
       preLoginHandler: function (formData, req, res, next) {
@@ -143,17 +143,17 @@ takes in four parameters:
   request directly.
 - ``res``: The Express response object.  This can be used to modify the HTTP
   response directly.
-- ``next``: The callback to call when you either want to return an error, or
-  want the login to continue processing. I.e. if you call this callback
-  with an error then the form will stop on that. But if you call it without
-  any arguments, then the form will just continue processing like normally.
+- ``next``: The callback to call after you have done your custom work.  If you
+  call this with an error then we immediately return this error to the user and
+  form processing stops.  But if you call it without an error, then our library
+  will continue to process the form and respond with the default behavior.
 
 In the example below, we'll use the ``preLoginHandler`` to validate that
 the user doesn't enter an email domain that is restricted::
 
     app.use(stormpath.init(app, {
       preLoginHandler: function (formData, req, res, next) {
-        if (formData.email.indexOf('@some-domain.com') !== -1) {
+        if (formData.login.indexOf('@some-domain.com') !== -1) {
           return next(new Error('You\'re not allowed to login with \'@some-domain.com\'.'));
         }
 

--- a/docs/registration.rst
+++ b/docs/registration.rst
@@ -222,6 +222,53 @@ automatically when they register.  This can be achieved with this config::
 
 By default the nextUri is to the `/` page, but you can modify this.
 
+.. _pre_registration_handler:
+
+Pre Registration Handler
+------------------------
+
+Want to validate the form before it's handled, then this is the event
+that you want to handle!
+
+By defining a ``preRegistrationHandler`` you're able to do intercept the
+form request and do validation.
+
+To use a ``preRegistrationHandler`` you need to define your handler function
+in the Stormpath middleware setup::
+
+    app.use(stormpath.init(app, {
+      preRegistrationHandler: function (formData, req, res, next) {
+        console.log('Got registration request', formData);
+        next();
+      }
+    }));
+
+As you can see in the example above, the ``preRegistrationHandler`` function
+takes in four parameters:
+
+- ``formData``: The data submitted in the form.
+- ``req``: The Express request object.  This can be used to modify the incoming
+  request directly.
+- ``res``: The Express response object.  This can be used to modify the HTTP
+  response directly.
+- ``next``: The callback to call when you either want to return an error, or
+  want to registration to continue processing. I.e. if you call this callback
+  with an error then the form will stop on that. But if you call it without
+  any arguments, then the form will just continue processing like normally.
+
+In the example below, we'll use the ``preRegistrationHandler`` to validate that
+the user doesn't enter an email domain that is restricted::
+
+    app.use(stormpath.init(app, {
+      preRegistrationHandler: function (formData, req, res, next) {
+        if (formData.email.indexOf('@some-domain.com') !== -1) {
+          return next(new Error('You\'re not allowed to register with \'@some-domain.com\'.'));
+        }
+
+        next();
+      }
+    }));
+
 .. _post_registration_handler:
 
 Post Registration Handler
@@ -244,7 +291,7 @@ in the Stormpath middleware setup::
       postRegistrationHandler: function (account, req, res, next) {
         console.log('User:', account.email, 'just registered!');
         next();
-      },
+      }
     }));
 
 As you can see in the example above, the ``postRegistrationHandler`` function
@@ -265,7 +312,7 @@ user to a special page (*instead of the normal registration flow*)::
     app.use(stormpath.init(app, {
       postRegistrationHandler: function (account, req, res, next) {
         res.redirect(302, '/secretpage').end();
-      },
+      }
     }));
 
 .. _json_registration_api:

--- a/docs/registration.rst
+++ b/docs/registration.rst
@@ -227,14 +227,11 @@ By default the nextUri is to the `/` page, but you can modify this.
 Pre Registration Handler
 ------------------------
 
-Want to validate the form before it's handled, then this is the event
-that you want to handle!
+Want to validate or modify the form data before it's handled by us? Then this is
+the handler that you want to use!
 
-By defining a ``preRegistrationHandler`` you're able to do intercept the
-form request and do validation.
-
-To use a ``preRegistrationHandler`` you need to define your handler function
-in the Stormpath middleware setup::
+To use a ``preRegistrationHandler`` you need to define your handler function in
+the Stormpath middleware setup::
 
     app.use(stormpath.init(app, {
       preRegistrationHandler: function (formData, req, res, next) {
@@ -251,10 +248,10 @@ takes in four parameters:
   request directly.
 - ``res``: The Express response object.  This can be used to modify the HTTP
   response directly.
-- ``next``: The callback to call when you either want to return an error, or
-  want the registration to continue processing. I.e. if you call this callback
-  with an error then the form will stop on that. But if you call it without
-  any arguments, then the form will just continue processing like normally.
+- ``next``: The callback to call after you have done your custom work.  If you
+  call this with an error then we immediately return this error to the user and
+  form processing stops.  But if you call it without an error, then our library
+  will continue to process the form and respond with the default behavior.
 
 In the example below, we'll use the ``preRegistrationHandler`` to validate that
 the user doesn't enter an email domain that is restricted::

--- a/docs/registration.rst
+++ b/docs/registration.rst
@@ -252,7 +252,7 @@ takes in four parameters:
 - ``res``: The Express response object.  This can be used to modify the HTTP
   response directly.
 - ``next``: The callback to call when you either want to return an error, or
-  want to registration to continue processing. I.e. if you call this callback
+  want the registration to continue processing. I.e. if you call this callback
   with an error then the form will stop on that. But if you call it without
   any arguments, then the form will just continue processing like normally.
 

--- a/lib/controllers/login.js
+++ b/lib/controllers/login.js
@@ -69,7 +69,7 @@ module.exports = function (req, res, next) {
     var preLoginHandler = config.preLoginHandler;
 
     if (preLoginHandler) {
-      return preLoginHandler(req, res, callback, formData);
+      return preLoginHandler(formData, req, res, callback);
     }
 
     callback();

--- a/lib/controllers/login.js
+++ b/lib/controllers/login.js
@@ -65,6 +65,16 @@ module.exports = function (req, res, next) {
 
   res.locals.status = req.query.status;
 
+  function handlePreLogin(formData, callback) {
+    var preLoginHandler = config.preLoginHandler;
+
+    if (preLoginHandler) {
+      return preLoginHandler(req, res, callback, formData);
+    }
+
+    callback();
+  }
+
   helpers.handleAcceptRequest(req, res, {
     'application/json': function () {
       switch (req.method) {
@@ -88,12 +98,18 @@ module.exports = function (req, res, next) {
             return helpers.loginWithOAuthProvider(req.body, req, res);
           }
 
-          authenticate(application, req.body, function (err, result) {
+          handlePreLogin(req.body, function (err) {
             if (err) {
               return helpers.writeJsonError(res, err);
             }
 
-            helpers.loginResponder(result.authenticationResult, result.account, req, res);
+            authenticate(application, req.body, function (err, result) {
+              if (err) {
+                return helpers.writeJsonError(res, err);
+              }
+
+              helpers.loginResponder(result.authenticationResult, result.account, req, res);
+            });
           });
           break;
 
@@ -102,7 +118,6 @@ module.exports = function (req, res, next) {
       }
     },
     'text/html': function () {
-
       var nextUri = url.parse(req.query.next || '').path;
 
       if (req.user && config.web.login.enabled) {
@@ -139,12 +154,18 @@ module.exports = function (req, res, next) {
         // If we get here, it means the user is submitting a login request, so we
         // should attempt to log the user into their account.
         success: function (form) {
-          authenticate(application, form.data, function (err, result) {
+          handlePreLogin(form.data, function (err) {
             if (err) {
-              return renderForm(form, { error: err.userMessage });
+              return renderForm(form, { error: err.userMessage || err.message });
             }
 
-            helpers.loginResponder(result.authenticationResult, result.account, req, res);
+            authenticate(application, form.data, function (err, result) {
+              if (err) {
+                return renderForm(form, { error: err.userMessage || err.message });
+              }
+
+              helpers.loginResponder(result.authenticationResult, result.account, req, res);
+            });
           });
         },
         // If we get here, it means the user didn't supply required form fields.

--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -114,7 +114,7 @@ module.exports = function (req, res, next) {
     var preRegistrationHandler = config.preRegistrationHandler;
 
     if (preRegistrationHandler) {
-      return preRegistrationHandler(req, res, callback, formData);
+      return preRegistrationHandler(formData, req, res, callback);
     }
 
     callback();

--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -15,10 +15,11 @@ var helpers = require('../helpers');
  *
  * @function
  *
- * @param {Object} config - The express-stormpath configuration object
+ * @param {Object} req - The http request.
  * @param {Object} res - The http response.
  */
-function defaultUnverifiedHtmlResponse(config, res) {
+function defaultUnverifiedHtmlResponse(req, res) {
+  var config = req.app.get('stormpathConfig');
   res.redirect(302, config.web.login.uri + '?status=unverified');
 }
 
@@ -31,10 +32,11 @@ function defaultUnverifiedHtmlResponse(config, res) {
  *
  * @function
  *
- * @param {Object} config - The express-stormpath configuration object
+ * @param {Object} req - The http request.
  * @param {Object} res - The http response.
  */
-function defaultCreatedHtmlResponse(config, res) {
+function defaultCreatedHtmlResponse(req, res) {
+  var config = req.app.get('stormpathConfig');
   res.redirect(302, config.web.login.uri + '?status=created');
 }
 
@@ -47,11 +49,11 @@ function defaultCreatedHtmlResponse(config, res) {
  *
  * @function
  *
- * @param {Object} config - The express-stormpath configuration object
  * @param {Object} req - The http request.
  * @param {Object} res - The http response.
  */
-function defaultAutoAuthorizeHtmlResponse(config, req, res) {
+function defaultAutoAuthorizeHtmlResponse(req, res) {
+  var config = req.app.get('stormpathConfig');
   res.redirect(302, url.parse(req.query.next || '').path || config.web.register.nextUri);
 }
 
@@ -106,8 +108,17 @@ module.exports = function (req, res, next) {
   var authenticator = new stormpath.OAuthPasswordGrantRequestAuthenticator(application);
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
-  var postRegistrationHandler = config.postRegistrationHandler;
   var view = config.web.register.view;
+
+  function handleResponse(account, responseHandler) {
+    var postRegistrationHandler = config.postRegistrationHandler;
+
+    if (postRegistrationHandler) {
+      return postRegistrationHandler(account, req, res, responseHandler.bind(null, req, res));
+    }
+
+    responseHandler(req, res);
+  }
 
   helpers.getFormViewModel('register', config, function (err, viewModel) {
     if (err) {
@@ -139,7 +150,7 @@ module.exports = function (req, res, next) {
                     req.user = expandedAccount;
 
                     if (config.web.register.autoLogin) {
-                      return authenticator.authenticate({
+                      authenticator.authenticate({
                         username: req.body.email || uuid(),
                         password: req.body.password || uuid()
                       }, function (err, passwordGrantAuthenticationResult) {
@@ -149,19 +160,11 @@ module.exports = function (req, res, next) {
 
                         helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
 
-                        if (postRegistrationHandler) {
-                          return postRegistrationHandler(expandedAccount, req, res, defaultJsonResponse.bind(null, req, res));
-                        }
-
-                        defaultJsonResponse(req, res);
+                        handleResponse(expandedAccount, defaultJsonResponse);
                       });
+                    } else {
+                      handleResponse(expandedAccount, defaultJsonResponse);
                     }
-
-                    if (postRegistrationHandler) {
-                      return postRegistrationHandler(expandedAccount, req, res, defaultJsonResponse.bind(null, req, res));
-                    }
-
-                    defaultJsonResponse(req, res);
                   });
                 });
               });
@@ -239,15 +242,11 @@ module.exports = function (req, res, next) {
                 req.user = expandedAccount;
 
                 if (expandedAccount.status === 'UNVERIFIED') {
-                  if (postRegistrationHandler) {
-                    return postRegistrationHandler(expandedAccount, req, res, defaultUnverifiedHtmlResponse.bind(null, config, res));
-                  }
-
-                  return defaultUnverifiedHtmlResponse(config, res);
+                  return handleResponse(expandedAccount, defaultUnverifiedHtmlResponse);
                 }
 
                 if (config.web.register.autoLogin) {
-                  return authenticator.authenticate({
+                  authenticator.authenticate({
                     username: req.body.email || uuid(),
                     password: req.body.password || uuid()
                   }, function (err, passwordGrantAuthenticationResult) {
@@ -262,21 +261,11 @@ module.exports = function (req, res, next) {
 
                     helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
 
-                    if (postRegistrationHandler) {
-                      return postRegistrationHandler(expandedAccount, req, res, defaultAutoAuthorizeHtmlResponse.bind(null, config, req, res));
-                    }
-
-                    defaultAutoAuthorizeHtmlResponse(config, req, res);
+                    handleResponse(expandedAccount, defaultAutoAuthorizeHtmlResponse);
                   });
+                } else {
+                  handleResponse(expandedAccount, defaultCreatedHtmlResponse);
                 }
-
-                if (postRegistrationHandler) {
-                  return postRegistrationHandler(expandedAccount, req, res, function () {
-                    return defaultCreatedHtmlResponse(config, res);
-                  });
-                }
-
-                return defaultCreatedHtmlResponse(config, res);
               });
             });
             break;

--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -192,15 +192,7 @@ module.exports = function (req, res, next) {
         }
       },
       'text/html': function () {
-        function writeFormErrors(errors) {
-          logger.info(errors);
-
-          return helpers.render(req, res, view, {
-            errors: errors,
-            form: helpers.sanitizeFormData(req.body),
-            formModel: viewModel.form
-          });
-        }
+        var writeFormError = helpers.writeFormError.bind(null, req, res, view, viewModel);
 
         switch (req.method) {
           // We should render the registration template.
@@ -227,12 +219,12 @@ module.exports = function (req, res, next) {
               function (callback) {
                 handlePreRegistration(req.body, function (err) {
                   if (err) {
-                    return writeFormErrors([err]);
+                    return writeFormError(err);
                   }
 
                   helpers.validateAccount(req.body, config, function (errors) {
                     if (errors) {
-                      return writeFormErrors(errors);
+                      return writeFormError(errors[0]);
                     }
 
                     callback();
@@ -255,7 +247,7 @@ module.exports = function (req, res, next) {
               }
             ], function (err, account) {
               if (err) {
-                return writeFormErrors([new Error(err.userMessage)]);
+                return writeFormError(err);
               }
 
               // If the account is unverified, we'll show a special message to the
@@ -273,7 +265,7 @@ module.exports = function (req, res, next) {
                     password: req.body.password || uuid()
                   }, function (err, passwordGrantAuthenticationResult) {
                     if (err) {
-                      return writeFormErrors([new Error(err.userMessage)]);
+                      return writeFormError(err);
                     }
 
                     helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);

--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -110,6 +110,16 @@ module.exports = function (req, res, next) {
   var logger = req.app.get('stormpathLogger');
   var view = config.web.register.view;
 
+  function handlePreRegistration(formData, callback) {
+    var preRegistrationHandler = config.preRegistrationHandler;
+
+    if (preRegistrationHandler) {
+      return preRegistrationHandler(req, res, callback, formData);
+    }
+
+    callback();
+  }
+
   function handleResponse(account, responseHandler) {
     var postRegistrationHandler = config.postRegistrationHandler;
 
@@ -135,36 +145,42 @@ module.exports = function (req, res, next) {
           case 'POST':
             applyDefaultAccountFields(config, req);
 
-            helpers.validateAccount(req.body, config, function (errors) {
-              if (errors) {
-                return helpers.writeJsonError(res, errors[0]);
+            handlePreRegistration(req.body, function (err) {
+              if (err) {
+                return helpers.writeJsonError(res, err);
               }
 
-              helpers.prepAccountData(req.body, config, function (accountData) {
-                application.createAccount(accountData, function (err, account) {
-                  if (err) {
-                    return helpers.writeJsonError(res, err);
-                  }
+              helpers.validateAccount(req.body, config, function (errors) {
+                if (errors) {
+                  return helpers.writeJsonError(res, errors[0]);
+                }
 
-                  helpers.expandAccount(account, config.expand, logger, function (err, expandedAccount) {
-                    req.user = expandedAccount;
-
-                    if (config.web.register.autoLogin) {
-                      authenticator.authenticate({
-                        username: req.body.email || uuid(),
-                        password: req.body.password || uuid()
-                      }, function (err, passwordGrantAuthenticationResult) {
-                        if (err) {
-                          return helpers.writeJsonError(res, err);
-                        }
-
-                        helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
-
-                        handleResponse(expandedAccount, defaultJsonResponse);
-                      });
-                    } else {
-                      handleResponse(expandedAccount, defaultJsonResponse);
+                helpers.prepAccountData(req.body, config, function (accountData) {
+                  application.createAccount(accountData, function (err, account) {
+                    if (err) {
+                      return helpers.writeJsonError(res, err);
                     }
+
+                    helpers.expandAccount(account, config.expand, logger, function (err, expandedAccount) {
+                      req.user = expandedAccount;
+
+                      if (config.web.register.autoLogin) {
+                        authenticator.authenticate({
+                          username: req.body.email || uuid(),
+                          password: req.body.password || uuid()
+                        }, function (err, passwordGrantAuthenticationResult) {
+                          if (err) {
+                            return helpers.writeJsonError(res, err);
+                          }
+
+                          helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);
+
+                          handleResponse(expandedAccount, defaultJsonResponse);
+                        });
+                      } else {
+                        handleResponse(expandedAccount, defaultJsonResponse);
+                      }
+                    });
                   });
                 });
               });
@@ -176,6 +192,16 @@ module.exports = function (req, res, next) {
         }
       },
       'text/html': function () {
+        function writeFormErrors(errors) {
+          logger.info(errors);
+
+          return helpers.render(req, res, view, {
+            errors: errors,
+            form: helpers.sanitizeFormData(req.body),
+            formModel: viewModel.form
+          });
+        }
+
         switch (req.method) {
           // We should render the registration template.
           case 'GET':
@@ -199,17 +225,18 @@ module.exports = function (req, res, next) {
                 callback();
               },
               function (callback) {
-                helpers.validateAccount(req.body, req.app.get('stormpathConfig'), function (errors) {
-                  if (errors) {
-                    logger.info(errors);
-                    return helpers.render(req, res, view, {
-                      errors: errors,
-                      form: helpers.sanitizeFormData(req.body),
-                      formModel: viewModel.form
-                    });
+                handlePreRegistration(req.body, function (err) {
+                  if (err) {
+                    return writeFormErrors([err]);
                   }
 
-                  callback();
+                  helpers.validateAccount(req.body, config, function (errors) {
+                    if (errors) {
+                      return writeFormErrors(errors);
+                    }
+
+                    callback();
+                  });
                 });
               },
               function (callback) {
@@ -228,12 +255,7 @@ module.exports = function (req, res, next) {
               }
             ], function (err, account) {
               if (err) {
-                logger.info(err);
-                return helpers.render(req, res, view, {
-                  errors: [new Error(err.userMessage)],
-                  form: helpers.sanitizeFormData(req.body),
-                  formModel: viewModel.form
-                });
+                return writeFormErrors([new Error(err.userMessage)]);
               }
 
               // If the account is unverified, we'll show a special message to the
@@ -251,12 +273,7 @@ module.exports = function (req, res, next) {
                     password: req.body.password || uuid()
                   }, function (err, passwordGrantAuthenticationResult) {
                     if (err) {
-                      logger.info(err);
-                      return helpers.render(req, res, view, {
-                        errors: [new Error(err.userMessage)],
-                        form: helpers.sanitizeFormData(req.body),
-                        formModel: viewModel.form
-                      });
+                      return writeFormErrors([new Error(err.userMessage)]);
                     }
 
                     helpers.createSession(passwordGrantAuthenticationResult, expandedAccount, req, res);

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -11,6 +11,7 @@ module.exports = {
   getAppModuleVersion: require('./get-app-module-version'),
   handleAcceptRequest: require('./handle-accept-request'),
   writeJsonError: require('./write-json-error'),
+  writeFormError: require('./write-form-error'),
   loginResponder: require('./login-responder'),
   loginWithOAuthProvider: require('./login-with-oauth-provider'),
   prepAccountData: require('./prep-account-data'),

--- a/lib/helpers/write-form-error.js
+++ b/lib/helpers/write-form-error.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var render = require('./render');
+var sanitizeFormData = require('./sanitize-form-data');
+
+/**
+ * Use this method to render form error responses.
+ *
+ * @function
+ *
+ * @param {Object} req - Express http request.
+ * @param {Object} res - Express http response.
+ * @param {Object} view - View to render.
+ * @param {Object} viewModel - Model to render the view with.
+ * @param {Object} err - Error to render.
+ */
+module.exports = function writeFormError(req, res, view, viewModel, err) {
+  var logger = req.app.get('stormpathLogger');
+
+  logger.info(err);
+
+  // Default to the user message if specified.
+  err.message = err.userMessage || err.message;
+
+  render(req, res, view, {
+    errors: [err],
+    form: sanitizeFormData(req.body),
+    formModel: viewModel.form
+  });
+};

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "js-yaml": "^3.4.3",
     "mocha": "^2.1.0",
     "mocha-lcov-reporter": "^1.0.0",
+    "sinon": "^1.17.3",
     "supertest": "^1.1.0"
   }
 }

--- a/test/handlers/test-pre-login-handler.js
+++ b/test/handlers/test-pre-login-handler.js
@@ -1,0 +1,212 @@
+'use strict';
+
+var sinon = require('sinon');
+var assert = require('assert');
+var request = require('supertest');
+
+var helpers = require('../helpers');
+
+function preLoginHandlerSpyTestFixture(sandbox, application, callback) {
+  var fixture = {
+    preLoginHandlerSpy: sandbox.spy(function (formData, req, res, next) {
+      next();
+    })
+  };
+
+  var app = helpers.createStormpathExpressApp({
+    application: application,
+    preLoginHandler: fixture.preLoginHandlerSpy
+  });
+
+  fixture.expressApp = app;
+
+  app.on('stormpath.ready', callback.bind(null, fixture));
+}
+
+function preLoginHandlerErrorTestFixture(application, respondWithError, callback) {
+  var app = helpers.createStormpathExpressApp({
+    application: application,
+    preLoginHandler: function (formData, req, res, next) {
+      next(respondWithError);
+    }
+  });
+
+  var fixture = {
+    expressApp: app
+  };
+
+  app.on('stormpath.ready', callback.bind(null, fixture));
+}
+
+function preLoginHandlerInterceptResponseTestFixture(application, respondWith, callback) {
+  var app = helpers.createStormpathExpressApp({
+    application: application,
+    preLoginHandler: function (formData, req, res) {
+      res.json(respondWith);
+      res.end();
+    }
+  });
+
+  var fixture = {
+    expressApp: app
+  };
+
+  app.on('stormpath.ready', callback.bind(null, fixture));
+}
+
+describe('Pre-Login Handler', function () {
+  var sandbox;
+  var application = null;
+  var usernamePasswordBody;
+  var newUser = helpers.newUser();
+
+  before(function (done) {
+    sandbox = sinon.sandbox.create();
+
+    usernamePasswordBody = {
+      username: newUser.email,
+      password: newUser.password
+    };
+
+    helpers.createApplication(helpers.createClient(), function (err, app) {
+      if (err) {
+        return done(err);
+      }
+
+      application = app;
+
+      application.createAccount(newUser, done);
+    });
+  });
+
+  after(function (done) {
+    sandbox.restore();
+    helpers.destroyApplication(application, done);
+  });
+
+  describe('when calling POST /login', function () {
+    describe('with a preLoginHandler', function () {
+      describe('the handler', function () {
+        var preLoginHandlerSpy;
+
+        before(function (done) {
+          preLoginHandlerSpyTestFixture(sandbox, application, function (fixture) {
+            request(fixture.expressApp)
+              .post('/login')
+              .set('Accept', 'application/json')
+              .type('json')
+              .send(usernamePasswordBody)
+              .expect('Set-Cookie', /access_token=[^;]+/)
+              .expect(200)
+              .end(function (err) {
+                if (err) {
+                  return done(err);
+                }
+
+                preLoginHandlerSpy = fixture.preLoginHandlerSpy;
+
+                done();
+              });
+          });
+        });
+
+        it('should be called once', function () {
+          assert(preLoginHandlerSpy.calledOnce);
+        });
+
+        it('should have the first argument be the formData object', function () {
+          var firstArgument = preLoginHandlerSpy.getCall(0).args[0];
+          assert(typeof firstArgument === 'object');
+          assert(firstArgument.grant_type === 'password');
+          assert(firstArgument.username === newUser.email);
+          assert(firstArgument.password === newUser.password);
+        });
+
+        it('should have the second argument be the request object', function () {
+          var secondArgument = preLoginHandlerSpy.getCall(0).args[1];
+          assert(typeof secondArgument === 'object');
+          assert(typeof secondArgument.body === 'object');
+          assert(typeof secondArgument.query === 'object');
+          assert(typeof secondArgument.method === 'string');
+          assert(typeof secondArgument.path === 'string');
+        });
+
+        it('should have the third argument be the response object', function () {
+          var thirdArgument = preLoginHandlerSpy.getCall(0).args[2];
+          assert(typeof thirdArgument === 'object');
+          assert(typeof thirdArgument.json === 'function');
+          assert(typeof thirdArgument.write === 'function');
+          assert(typeof thirdArgument.end === 'function');
+        });
+
+        it('should have the fourth argument be the next callback', function () {
+          var fourthArgument = preLoginHandlerSpy.getCall(0).args[3];
+          assert(typeof fourthArgument === 'function');
+        });
+
+        describe('when providing your own response', function () {
+          var expressApp, customResponse;
+
+          before(function (done) {
+            customResponse = { test: '6ba109b3-2cdf-421c-8cc0-e22bc7550d0b' };
+            preLoginHandlerInterceptResponseTestFixture(application, customResponse, function (fixture) {
+              expressApp = fixture.expressApp;
+              done();
+            });
+          });
+
+          it('should return that response', function (done) {
+            request(expressApp)
+              .post('/login')
+              .set('Accept', 'application/json')
+              .type('json')
+              .send(usernamePasswordBody)
+              .expect(200)
+              .end(function (err, res) {
+                if (err) {
+                  return done(err);
+                }
+
+                assert(typeof res.body === 'object');
+                assert(res.body.test === customResponse.test);
+
+                done();
+              });
+          });
+        });
+
+        describe('when calling next(err)', function () {
+          var expressApp, respondWithError;
+
+          before(function (done) {
+            respondWithError = new Error('54e3ea32-3366-4a25-a774-53fd93b1746e');
+            preLoginHandlerErrorTestFixture(application, respondWithError, function (fixture) {
+              expressApp = fixture.expressApp;
+              done();
+            });
+          });
+
+          it('should write the error to the response', function (done) {
+            request(expressApp)
+              .post('/login')
+              .set('Accept', 'application/json')
+              .type('json')
+              .send(usernamePasswordBody)
+              .expect(400)
+              .end(function (err, res) {
+                if (err) {
+                  return done(err);
+                }
+
+                assert(typeof res.body === 'object');
+                assert(res.body.status === 400);
+                assert(res.body.message === respondWithError.message);
+
+                done();
+              });
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/handlers/test-pre-registration-handler.js
+++ b/test/handlers/test-pre-registration-handler.js
@@ -1,0 +1,208 @@
+'use strict';
+
+var sinon = require('sinon');
+var assert = require('assert');
+var request = require('supertest');
+
+var helpers = require('../helpers');
+
+function preRegistrationHandlerSpyTestFixture(sandbox, application, callback) {
+  var fixture = {
+    preRegistrationHandlerSpy: sandbox.spy(function (formData, req, res, next) {
+      next();
+    })
+  };
+
+  var app = helpers.createStormpathExpressApp({
+    application: application,
+    preRegistrationHandler: fixture.preRegistrationHandlerSpy
+  });
+
+  fixture.expressApp = app;
+
+  app.on('stormpath.ready', callback.bind(null, fixture));
+}
+
+function preRegistrationHandlerErrorTestFixture(application, respondWithError, callback) {
+  var app = helpers.createStormpathExpressApp({
+    application: application,
+    preRegistrationHandler: function (formData, req, res, next) {
+      next(respondWithError);
+    }
+  });
+
+  var fixture = {
+    expressApp: app
+  };
+
+  app.on('stormpath.ready', callback.bind(null, fixture));
+}
+
+function preRegistrationHandlerInterceptResponseTestFixture(application, respondWith, callback) {
+  var app = helpers.createStormpathExpressApp({
+    application: application,
+    preRegistrationHandler: function (formData, req, res) {
+      res.json(respondWith);
+      res.end();
+    }
+  });
+
+  var fixture = {
+    expressApp: app
+  };
+
+  app.on('stormpath.ready', callback.bind(null, fixture));
+}
+
+describe('Pre-Registration Handler', function () {
+  var sandbox;
+  var application = null;
+  var newUser = helpers.newUser();
+
+  before(function (done) {
+    sandbox = sinon.sandbox.create();
+
+    helpers.createApplication(helpers.createClient(), function (err, app) {
+      if (err) {
+        return done(err);
+      }
+
+      application = app;
+
+      done();
+    });
+  });
+
+  after(function (done) {
+    sandbox.restore();
+    helpers.destroyApplication(application, done);
+  });
+
+  describe('when calling POST /register', function () {
+    describe('with a preRegistrationHandler', function () {
+      describe('the handler', function () {
+        var preRegistrationHandlerSpy;
+
+        before(function (done) {
+          preRegistrationHandlerSpyTestFixture(sandbox, application, function (fixture) {
+            request(fixture.expressApp)
+              .post('/register')
+              .set('Accept', 'application/json')
+              .type('json')
+              .send(newUser)
+              .expect(200)
+              .end(function (err) {
+                if (err) {
+                  return done(err);
+                }
+
+                preRegistrationHandlerSpy = fixture.preRegistrationHandlerSpy;
+
+                done();
+              });
+          });
+        });
+
+        it('should be called once', function () {
+          assert(preRegistrationHandlerSpy.calledOnce);
+        });
+
+        it('should have the first argument be the formData object', function () {
+          var firstArgument = preRegistrationHandlerSpy.getCall(0).args[0];
+
+          assert(typeof firstArgument === 'object');
+          assert(Object.keys(firstArgument).length === Object.keys(newUser).length);
+
+          for (var key in newUser) {
+            assert(firstArgument[key] === newUser[key]);
+          }
+        });
+
+        it('should have the second argument be the request object', function () {
+          var secondArgument = preRegistrationHandlerSpy.getCall(0).args[1];
+          assert(typeof secondArgument === 'object');
+          assert(typeof secondArgument.body === 'object');
+          assert(typeof secondArgument.query === 'object');
+          assert(typeof secondArgument.method === 'string');
+          assert(typeof secondArgument.path === 'string');
+        });
+
+        it('should have the third argument be the response object', function () {
+          var thirdArgument = preRegistrationHandlerSpy.getCall(0).args[2];
+          assert(typeof thirdArgument === 'object');
+          assert(typeof thirdArgument.json === 'function');
+          assert(typeof thirdArgument.write === 'function');
+          assert(typeof thirdArgument.end === 'function');
+        });
+
+        it('should have the fourth argument be the next callback', function () {
+          var fourthArgument = preRegistrationHandlerSpy.getCall(0).args[3];
+          assert(typeof fourthArgument === 'function');
+        });
+
+        describe('when providing your own response', function () {
+          var expressApp, customResponse;
+
+          before(function (done) {
+            customResponse = { test: 'bea99bcd-05e5-4870-a0df-ec7aae996596' };
+            preRegistrationHandlerInterceptResponseTestFixture(application, customResponse, function (fixture) {
+              expressApp = fixture.expressApp;
+              done();
+            });
+          });
+
+          it('should return that response', function (done) {
+            request(expressApp)
+              .post('/register')
+              .set('Accept', 'application/json')
+              .type('json')
+              .send(newUser)
+              .expect(200)
+              .end(function (err, res) {
+                if (err) {
+                  return done(err);
+                }
+
+                assert(typeof res.body === 'object');
+                assert(res.body.test === customResponse.test);
+
+                done();
+              });
+          });
+        });
+
+        describe('when calling next(err)', function () {
+          var expressApp, respondWithError;
+
+          before(function (done) {
+            respondWithError = new Error('499d8376-c5db-4bb5-a175-562888c6dcef');
+            preRegistrationHandlerErrorTestFixture(application, respondWithError, function (fixture) {
+              expressApp = fixture.expressApp;
+              done();
+            });
+          });
+
+          it('should write the error to the response', function (done) {
+            request(expressApp)
+              .post('/register')
+              .set('Accept', 'application/json')
+              .type('json')
+              .send(newUser)
+              .expect(400)
+              .end(function (err, res) {
+                if (err) {
+                  return done(err);
+                }
+
+                assert(typeof res.body === 'object');
+                assert(res.body.status === 400);
+                assert(res.body.message === respondWithError.message);
+
+                done();
+              });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds support for the `preRegistrationHandler` and `preLoginHandler`.

#### How to verify

1. Checkout this branch.
2. Link it (`$ npm link`).
3. Create a new test application using [this gist](https://gist.github.com/typerandom/94ed68b0ff541bf84597).
4. Link to our branch (`$ npm link express-stormpath`).
5. Start the application.
6. Navigate to `/register`.
7. Try and register with the email `test@test.com`.
8. Verify that you receive the error message `You're not allowed to register as 'test@test.com'.`.
9. Change the email to your own and set a really short password.
10. Verify that you receive an error stating that your password is too short.
11. Register for a new account.
12. Verify that the registration process works as expected.
13. Logout from your account.
14. Navigate to `/login`.
15. Try to login as `test@test.com`.
16. Verify that you receive the error message `You're not allowed to login as 'test@test.com'.`.
17. Enter an invalid username and password.
18. Verify that you receive a `username or password is invalid` error.
19. Enter the username and password that you previously registered with.
20. Verify that you are able to login as expected.

Fixes #299.