### PR TITLE
Fix: Invalidate cache at logout

### DIFF
--- a/lib/controllers/logout.js
+++ b/lib/controllers/logout.js
@@ -17,29 +17,46 @@ var idSiteRedirect = require('./id-site-redirect');
  * @param {function} next - The next function.
  */
 module.exports = function (req, res, next) {
-  var config = req.app.get('stormpathConfig');
+  function cleanupSession(callback) {
+    helpers.getUser(req, res, function () {
+      // Retrieve the user and remove it from the request.
+      var account = req.user;
+      delete req['user'];
 
-  function removeTokens() {
-    middleware.revokeTokens(req, res);
-    middleware.deleteCookies(req, res);
+      // Remove tokens.
+      middleware.revokeTokens(req, res);
+      middleware.deleteCookies(req, res);
+
+      // If we have have an account, then invalidate the cache for it.
+      if (account) {
+        return account.invalidate(function () {
+          callback();
+        });
+      }
+
+      callback();
+    });
   }
 
   helpers.handleAcceptRequest(req, res, {
     'application/json': function () {
-      removeTokens();
-      res.status(200).end();
+      cleanupSession(function () {
+        res.status(200).end();
+      });
     },
     'text/html': function () {
-      removeTokens();
+      cleanupSession(function () {
+        var config = req.app.get('stormpathConfig');
 
-      if (config.web.idSite.enabled) {
-        return idSiteRedirect({ logout: true })(req, res);
-      }
+        if (config.web.idSite.enabled) {
+          return idSiteRedirect({ logout: true })(req, res);
+        }
 
-      var queryNextPath = url.parse(req.query.next || '').path;
-      var nextUri = queryNextPath || config.web.logout.nextUri;
+        var queryNextPath = url.parse(req.query.next || '').path;
+        var nextUri = queryNextPath || config.web.logout.nextUri;
 
-      res.redirect(nextUri);
+        res.redirect(nextUri);
+      });
     }
   }, next);
 };


### PR DESCRIPTION
Invalidates the account cache when the `/logout` endpoint is called.

#### Note

This depends on https://github.com/stormpath/stormpath-sdk-node/pull/407 in order to function. So the Node SDK need to cut a new release with that PR before we can release this.

#### How to verify

Run the steps of [this PR](https://github.com/stormpath/stormpath-sdk-node/pull/407). It will use this branch and verify the behaviour.

Fixes #278.