### PR TITLE
Add support for postLogoutHandler

### DIFF
--- a/docs/logout.rst
+++ b/docs/logout.rst
@@ -31,7 +31,7 @@ Post Logout Handler
 ------------------
 
 Want to run some custom code after a user has logged out of your site?
-By defining a ``postLogoutHandler`` you're able do just that!
+By defining a ``postLogoutHandler`` you're able to do just that!
 
 To use a ``postLogoutHandler``, you need to define your handler function
 in the Stormpath config::
@@ -44,7 +44,7 @@ in the Stormpath config::
     }));
 
 As you can see in the example above, the ``postLogoutHandler`` function
-takes in four parameters:
+takes four parameters:
 
 - ``account``: The successfully logged out user account.
 - ``req``: The Express request object.  This can be used to modify the incoming

--- a/docs/logout.rst
+++ b/docs/logout.rst
@@ -25,3 +25,41 @@ following configuration::
       }
     }
 
+.. _post_logout_handler:
+
+Post Logout Handler
+------------------
+
+Want to run some custom code after a user logout out of your site?
+By defining a ``postLogoutHandler`` you're able do just that!
+
+To use a ``postLogoutHandler``, you need to define your handler function
+in the Stormpath config::
+
+    app.use(stormpath.init(app, {
+      postLogoutHandler: function (account, req, res, next) {
+        console.log('User', account.email, 'just logged out!');
+        next();
+      }
+    }));
+
+As you can see in the example above, the ``postLogoutHandler`` function
+takes in four parameters:
+
+- ``account``: The successfully logged out user account.
+- ``req``: The Express request object.  This can be used to modify the incoming
+  request directly.
+- ``res``: The Express response object.  This can be used to modify the HTTP
+  response directly.
+- ``next``: The callback to call when you're done doing whatever it is you want
+  to do.  If you call this, execution will continue on normally.  If you don't
+  call this, you're responsible for handling the response.
+
+In the example below, we'll use the ``postLogoutHandler`` to redirect the
+user to a special page (*instead of the normal logout flow*)::
+
+    app.use(stormpath.init(app, {
+      postLogoutHandler: function (account, req, res, next) {
+        res.redirect(302, '/secretpage').end();
+      }
+    }));

--- a/docs/logout.rst
+++ b/docs/logout.rst
@@ -30,7 +30,7 @@ following configuration::
 Post Logout Handler
 ------------------
 
-Want to run some custom code after a user logout out of your site?
+Want to run some custom code after a user has logged out of your site?
 By defining a ``postLogoutHandler`` you're able do just that!
 
 To use a ``postLogoutHandler``, you need to define your handler function
@@ -60,6 +60,6 @@ user to a special page (*instead of the normal logout flow*)::
 
     app.use(stormpath.init(app, {
       postLogoutHandler: function (account, req, res, next) {
-        res.redirect(302, '/secretpage').end();
+        res.redirect(302, '/farewell').end();
       }
     }));

--- a/lib/controllers/logout.js
+++ b/lib/controllers/logout.js
@@ -17,37 +17,54 @@ var idSiteRedirect = require('./id-site-redirect');
  * @param {function} next - The next function.
  */
 module.exports = function (req, res, next) {
+  var config = req.app.get('stormpathConfig');
+
   function cleanupSession(callback) {
+    // Retrieve the user and remove it from the request.
+    var account = req.user;
+    delete req['user'];
+
+    // Remove tokens.
+    middleware.revokeTokens(req, res);
+    middleware.deleteCookies(req, res);
+
+    // If we have have an account, then invalidate the cache for it.
+    if (account) {
+      return account.invalidate(function () {
+        callback();
+      });
+    }
+
+    callback();
+  }
+
+  function handlePostLogout(account, callback) {
+    var postLogoutHandler = config.postLogoutHandler;
+
+    if (postLogoutHandler) {
+      return postLogoutHandler(account, req, res, callback);
+    }
+
+    callback();
+  }
+
+  function handleLogout(callback) {
     helpers.getUser(req, res, function () {
-      // Retrieve the user and remove it from the request.
       var account = req.user;
-      delete req['user'];
-
-      // Remove tokens.
-      middleware.revokeTokens(req, res);
-      middleware.deleteCookies(req, res);
-
-      // If we have have an account, then invalidate the cache for it.
-      if (account) {
-        return account.invalidate(function () {
-          callback();
-        });
-      }
-
-      callback();
+      cleanupSession(function () {
+        handlePostLogout(account, callback);
+      });
     });
   }
 
   helpers.handleAcceptRequest(req, res, {
     'application/json': function () {
-      cleanupSession(function () {
+      handleLogout(function () {
         res.status(200).end();
       });
     },
     'text/html': function () {
-      cleanupSession(function () {
-        var config = req.app.get('stormpathConfig');
-
+      handleLogout(function () {
         if (config.web.idSite.enabled) {
           return idSiteRedirect({ logout: true })(req, res);
         }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint": "^2.2.0",
     "istanbul": "^0.4.0",
     "js-yaml": "^3.5.4",
-    "mocha": "^2.1.0",
+    "mocha": "^2.4.5",
     "mocha-lcov-reporter": "^1.0.0",
     "sinon": "^1.17.3",
     "supertest": "^1.1.0"

--- a/test/controllers/test-logout.js
+++ b/test/controllers/test-logout.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var sinon = require('sinon');
-var assert = require('assert');
 var request = require('supertest');
 var helpers = require('../helpers');
 

--- a/test/controllers/test-logout.js
+++ b/test/controllers/test-logout.js
@@ -108,8 +108,4 @@ describe('logout', function () {
       .expect('Location', '/goodbye')
       .end(done);
   });
-
-  it('should call the postLogoutHandler', function () {
-    assert(postLogoutHandlerSpy.callCount, 3);
-  });
 });

--- a/test/handlers/test-post-logout-handler.js
+++ b/test/handlers/test-post-logout-handler.js
@@ -1,0 +1,124 @@
+'use strict';
+
+var sinon = require('sinon');
+var assert = require('assert');
+var request = require('supertest');
+
+var helpers = require('../helpers');
+
+function postLogoutHandlerSpyTestFixture(sandbox, application, account, callback) {
+  var fixture = {
+    postLogoutHandlerSpy: sandbox.spy(function (formData, req, res, next) {
+      next();
+    })
+  };
+
+  var app = helpers.createStormpathExpressApp({
+    application: application,
+    postLogoutHandler: fixture.postLogoutHandlerSpy
+  }, function (req, res, next) {
+    req.user = account;
+    next();
+  });
+
+  fixture.expressApp = app;
+
+  app.on('stormpath.ready', callback.bind(null, fixture));
+}
+
+describe('Post-Logout Handler', function () {
+  var sandbox;
+  var application = null;
+  var account;
+  var newUser = helpers.newUser();
+
+  before(function (done) {
+    sandbox = sinon.sandbox.create();
+
+    helpers.createApplication(helpers.createClient(), function (err, app) {
+      if (err) {
+        return done(err);
+      }
+
+      application = app;
+
+      application.createAccount(newUser, function (err, newAccount) {
+        if (err) {
+          return done(err);
+        }
+
+        account = newAccount;
+
+        done();
+      });
+    });
+  });
+
+  after(function (done) {
+    sandbox.restore();
+    helpers.destroyApplication(application, done);
+  });
+
+  describe('when calling POST /logout', function () {
+    describe('with a postLogoutHandler', function () {
+      describe('the handler', function () {
+        var postLogoutHandlerSpy;
+
+        before(function (done) {
+          postLogoutHandlerSpyTestFixture(sandbox, application, account, function (fixture) {
+            request(fixture.expressApp)
+              .post('/logout')
+              .set('Accept', 'application/json')
+              .expect(200)
+              .end(function (err) {
+                if (err) {
+                  return done(err);
+                }
+
+                postLogoutHandlerSpy = fixture.postLogoutHandlerSpy;
+
+                done();
+              });
+          });
+        });
+
+        it('should be called once', function () {
+          assert(postLogoutHandlerSpy.calledOnce);
+        });
+
+        it('should have the first argument be the account object', function () {
+          var firstArgument = postLogoutHandlerSpy.getCall(0).args[0];
+
+          assert(typeof firstArgument === 'object');
+          assert(Object.keys(firstArgument).length === Object.keys(account).length);
+
+          for (var key in account) {
+            assert(firstArgument[key] === account[key]);
+          }
+        });
+
+        it('should have the second argument be the request object', function () {
+          var secondArgument = postLogoutHandlerSpy.getCall(0).args[1];
+          assert(typeof secondArgument === 'object');
+          assert(typeof secondArgument.body === 'object');
+          assert(typeof secondArgument.query === 'object');
+          assert(typeof secondArgument.method === 'string');
+          assert(typeof secondArgument.path === 'string');
+        });
+
+        it('should have the third argument be the response object', function () {
+          var thirdArgument = postLogoutHandlerSpy.getCall(0).args[2];
+          assert(typeof thirdArgument === 'object');
+          assert(typeof thirdArgument.json === 'function');
+          assert(typeof thirdArgument.write === 'function');
+          assert(typeof thirdArgument.end === 'function');
+        });
+
+        it('should have the fourth argument be the next callback', function () {
+          var fourthArgument = postLogoutHandlerSpy.getCall(0).args[3];
+          assert(typeof fourthArgument === 'function');
+        });
+      });
+    });
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -136,7 +136,7 @@ module.exports.setPasswordResetStatus = function (application, status, cb) {
   });
 };
 
-module.exports.createStormpathExpressApp = function (config) {
+module.exports.createStormpathExpressApp = function (config, preHandler) {
   config.client = {
     apiKey: {
       id: process.env.STORMPATH_CLIENT_APIKEY_ID,
@@ -145,6 +145,10 @@ module.exports.createStormpathExpressApp = function (config) {
   };
 
   var app = express();
+
+  if (preHandler) {
+    app.use(preHandler);
+  }
 
   app.use(stormpathExpress.init(app, config));
 


### PR DESCRIPTION
Adds support for the `postLogoutHandler`.

#### Before Reviewing

This depends on [stormpath-sdk-node/release-0.18.0](https://github.com/stormpath/stormpath-sdk-node/pull/411)

#### How to verify

1. Checkout this branch.
2. Link it (`$ npm link`).
3. Create a new test application using [this gist](https://gist.github.com/typerandom/f98d5867f9b7123c4873).
4. Link to our branch (`$ npm link express-stormpath`).
5. Start the application.
6. Navigate to `/login`.
7. Login as an existing user.
8. Navigate to `/logout`.
9. Click the logout button.
10. Check the console and verify that `'User logged out (account object)` is present.

Fixes #218.