### PR TITLE
Updates to the Setup and Configuration documentation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -76,7 +76,7 @@ Default Features
 ----------------
 
 When you add Stormpath to your application using ``app.use(stormpath.init(app))``,
-our module will automatically add the following routes to your applicationx:
+our module will automatically add the following routes to your application:
 
 +--------------+-------------------------------------------------------------+---------------------------+
 | URI          | Purpose                                                     | Documentation             |

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,13 +4,13 @@
 Configuration
 =============
 
-This module provides many options that allow you to customize the authentication
-features of your Express application.  We will cover the major options in this
+This module provides several options that allow you to customize the authentication
+features of your Express application. We will cover the major options in this
 section, and more specific options in later sections of this guide.
 
-If you would like a master list of all available options, please refer to the
+If you would like a list of all available options, please refer to the
 `Web Configuration Defaults`_ file in the library. This YAML file has comments
-which describe each option, and represents the defaults for all options.
+which describe each option and the value represents the option default.
 
 
 Environment Variables
@@ -43,14 +43,14 @@ variables, or in a number of other ways.
 
 .. note::
 
-    If you're using Heroku you don't need to specify your credentials or
-    application at all -- these values will be automatically populated for you.
+    If you're using Heroku you don't need to specify the credentials or
+    your application -- these values will be automatically provided for you.
 
 .. tip::
 
     You might also want to check out
     `autoenv <https://github.com/kennethreitz/autoenv>`_, a project that makes
-    working with environment variables simpler for Linux / Mac / BSD users.
+    working with environment variables simpler for Linux/Mac/BSD users.
 
 Inline Options
 ----------------
@@ -62,11 +62,11 @@ can do so like this:
 
   app.use(stormpath.init(app, {
     apiKey: {
-      id: 'xxxx',
-      secret: 'xxxx'
+      id: 'YOUR_ID_HERE',
+      secret: 'YOUR_SECRET_HERE'
     },
     application: {
-      href: `https://api.stormpath.com/v1/applications/xxxx`
+      href: `YOUR_APP_HREF`
     }
   }));
 
@@ -75,8 +75,8 @@ can do so like this:
 Default Features
 ----------------
 
-When you add Stormpath to your application, via ``app.use(stormpath.init(app))``,
-our module will add the following routes to your application by default:
+When you add Stormpath to your application using ``app.use(stormpath.init(app))``,
+our module will automatically add the following routes to your applicationx:
 
 +--------------+-------------------------------------------------------------+---------------------------+
 | URI          | Purpose                                                     | Documentation             |
@@ -96,8 +96,8 @@ our module will add the following routes to your application by default:
 | /verify      | Verify a new account, from a email verification link.       | :ref:`email_verification` |
 +--------------+-------------------------------------------------------------+---------------------------+
 
-Each featue has it's own options, please refer to the documentation of each
-feature.  If you want to disable specific features, continue to the next
+Each featue has its own options, please refer to the documentation of each
+feature. If you want to disable specific features, continue to the next
 section.
 
 Disabling Features
@@ -195,9 +195,8 @@ would be defined like this::
 This allows our framework to serve your SPA, for routes that this framework also
 wants to handle. You need this option if the following are true:
 
- * Your SPA is using HTML5 history mode
- * You want the default feature routes, such as ``/login`` to
-   serve your SPA
+ * Your SPA is using HTML5 history mode.
+ * You want the default feature routes, such as ``/login`` to serve your SPA.
  * You don't want to use our default login and registration views, you want your
    SPA to render those client-side.
 

--- a/docs/registration.rst
+++ b/docs/registration.rst
@@ -177,6 +177,7 @@ to your application, and modify it's password policy.
 
 For more information see `Account Password Strength Policy`_.
 
+.. _email_verification:
 
 Email Verification
 ------------------

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -5,7 +5,7 @@ Setup
 =====
 
 This section walks you through the basic setup for Express-Stormpath, by the end
-of this page you'll have login and registration features for your Express
+of this page you'll have setup login and registration features for your Express
 application!
 
 Create a Stormpath Account
@@ -18,39 +18,41 @@ create a new Stormpath account: https://api.stormpath.com/register
 Create an API Key Pair
 ----------------------
 
-Once you've created a new account, you need to create a new API key pair by
-logging into your dashboard and clicking the "Create an API Key" button.  This
-will generate a new API key for you, and prompt you to download your key pair.
+Once you've created a new account you need to create a new API key pair. A new
+API key pair is easily created by logging into your dashboard and clicking the
+"Create an API Key" button. This will generate a new API key for you, and
+prompt you to download your key pair.
 
 .. note::
     Please keep the API key pair file you just downloaded safe!  These two keys
     allow you to make Stormpath API requests, and should be properly protected,
     backed up, etc.
 
-Once you've downloaded your `apiKey.properties` file, save it to this location
-in your home directory:
+Once you've downloaded your `apiKey.properties` file, save it to the following
+location in your home directory:
 
 .. code-block:: sh
 
     ~/.stormpath/apiKey.properties
 
 To ensure no other users on your system can access the file, you'll also want to
-change the file's permissions.  You can do this by running:
+change the file's permissions. You can do this by opening up your terminal and
+running:
 
 .. code-block:: sh
 
     $ chmod go-rwx ~/.stormpath/apiKey.properties
 
 For the rest of this tutorial, we'll assume that you've placed this file in that
-location.  If you prefer to expose options with environment variables or
-configuration options, you can do that too!  Please see the :ref:`configuration`
-section for other options
+location. If you prefer to expose options with environment variables or
+configuration options, you can do that too! Please see the :ref:`configuration`
+section for other options.
 
 Find Your Stormpath Application
 -------------------------------
 
 All new Stormpath Tenants will have a Stormpath Application, called
-"My Application".  You'll generally want one application per project, and we can
+"My Application". You'll generally want one application per project, and we can
 use this default application to get started.
 
 An application has an HREF, and it looks like this:
@@ -67,9 +69,9 @@ To learn more about Stormpath Applications, please see the
 `Setting up Development and Production Environments`_
 
 .. note::
-    Your default Application will also have a directory mapped to it.  This is
-    where Stormpath stores accounts.  To learn more, please see the
-    `Directory Resource`_ and `Modeling Your User Base`_
+    Your default Application will also have a directory mapped to it. The
+    Directory is where Stormpath stores accounts. To learn more, please see
+    `Directory Resource`_ and `Modeling Your User Base`_.
 
 
 Now that you've created an Application, you're ready to plug Express-Stormpath
@@ -83,9 +85,9 @@ left to do before we can dive into the code is install the `Express-Stormpath`_
 package from `NPM`_.
 
 To install Express-Stormpath, you'll need ``npm``.  You can install the latest
-version of Express-Stormpath by running::
+version of Express-Stormpath by opening up your terminal and running::
 
-    $ npm install --save express-stormpath
+    $ npm install express-stormpath --save
 
 If you'd like to upgrade to the latest version of Express-Stormpath (*maybe you
 have an old version installed*), you can run::
@@ -115,16 +117,16 @@ Express application, it shows the minimal code required to integrate Stormpath:
       // Optional configuration options.
     }));
 
-    app.listen(3000);
-
-    // Stormpath will let you know when it's ready to start authenticating users.
-    app.on('stormpath.ready', function () {
-        console.log('Stormpath Ready!');
+    app.listen(3000, function (err) {
+      if (err) {
+        return console.error(err);
+      }
+      console.log('Server running on http://localhost:3000/');
     });
 
 With this minimal configuration, our library will do the following:
 
-- Fetch your Stormpath Application and all the data about it's configuration and
+- Fetch your Stormpath Application and all the data about its configuration and
   account stores.
 
 - Attach the :ref:`default_features` to your express application, such as the
@@ -132,21 +134,20 @@ With this minimal configuration, our library will do the following:
 
 - Hold any requests that require authentication, until Stormpath is ready.
 
-That's it, you're ready to go!  Try navigating to these URLs in your
-application:
+That's it, you're ready to go! Try navigating to these URLs in your application:
 
 - http://localhost:3000/login
 - http://localhost:3000/register
 
-You should be able to register for an account, and log in.  The newly created
+You should be able to register for an account and log in. The newly created
 account will be placed in the directory that is mapped to "My Application".
 
 .. note::
 
     By default, we don't require email verification for new accounts, but we
-    highly recommend you use this workflow.  You can enable email verification
-    from the directory of your Stormpath Application.  You can do this from our
-    `Admin Console`_.
+    highly recommend you use this workflow. You can enable email verification
+    by logging into the `Admin Console`_ and going to the the Workflows tab
+    for the directory of your Stormpath Application.
 
 There are many more features than login and registration, please continue to the
 next section to learn more!

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -4,9 +4,9 @@
 Setup
 =====
 
-This section covers the basic setup you need to perform in order to get started
-with Express-Stormpath.
-
+This section walks you through the basic setup for Express-Stormpath, by the end
+of this page you'll have login and registration features for your Express
+application!
 
 Create a Stormpath Account
 --------------------------
@@ -18,95 +18,62 @@ create a new Stormpath account: https://api.stormpath.com/register
 Create an API Key Pair
 ----------------------
 
-Once you've created a new account, create a new API key pair by logging into
-your dashboard and clicking the "Create an API Key" button.  This will generate
-a new API key for you, and prompt you to download your key pair.
+Once you've created a new account, you need to create a new API key pair by
+logging into your dashboard and clicking the "Create an API Key" button.  This
+will generate a new API key for you, and prompt you to download your key pair.
 
 .. note::
     Please keep the API key pair file you just downloaded safe!  These two keys
     allow you to make Stormpath API requests, and should be properly protected,
     backed up, etc.
 
-Once you've downloaded your `apiKey.properties` file, save it in your home
-directory in a file named `~/.stormpath/apiKey.properties`.  To ensure no other
-users on your system can access the file, you'll also want to change the file's
-permissions.  You can do this by running::
+Once you've downloaded your `apiKey.properties` file, save it to this location
+in your home directory:
+
+.. code-block:: sh
+
+    ~/.stormpath/apiKey.properties
+
+To ensure no other users on your system can access the file, you'll also want to
+change the file's permissions.  You can do this by running:
+
+.. code-block:: sh
 
     $ chmod go-rwx ~/.stormpath/apiKey.properties
 
+For the rest of this tutorial, we'll assume that you've placed this file in that
+location.  If you prefer to expose options with environment variables or
+configuration options, you can do that too!  Please see the :ref:`configuration`
+section for other options
 
-Create a Stormpath Application
-------------------------------
+Find Your Stormpath Application
+-------------------------------
 
-Next, you'll want to create a new Stormpath Application.
+All new Stormpath Tenants will have a Stormpath Application, called
+"My Application".  You'll generally want one application per project, and we can
+use this default application to get started.
 
-Stormpath allows you to provision any number of "Applications".  An
-"Application" is just Stormpath's term for a project.
+An application has an HREF, and it looks like this:
 
-Let's say you want to build a few separate websites.  One site named
-"dronewars.com", and another named "carswap.com".  In this case, you'd want to
-create two separate Stormpath Applications, one named "dronewars" and another
-named "carswap".  Each Stormpath Application should represent a real life
-application of some sort.
+.. code-block:: sh
 
-The general rule is that you should create one Application per website (or
-project).  Since we're just getting set up, you'll want to create a single
-Application.
+    https://api.stormpath.com/v1/applications/24kkU5XOz4tQlZ7sBtPUN6
 
-To do this, click the "Applications" tab in the Stormpath dashboard, then click
-"Register an Application" and follow the on-screen instructions.
+From inside the `Admin Console`_, you can find the HREF by navigating to the
+Application in the Application's list.
+
+To learn more about Stormpath Applications, please see the
+`Application Resource`_ and
+`Setting up Development and Production Environments`_
 
 .. note::
-    Use the default options when creating an Application, this way you'll be
-    able to create users in your new Application without issue.
+    Your default Application will also have a directory mapped to it.  This is
+    where Stormpath stores accounts.  To learn more, please see the
+    `Directory Resource`_ and `Modeling Your User Base`_
+
 
 Now that you've created an Application, you're ready to plug Express-Stormpath
 into your project!
-
-
-Bonus: Create a Directory
--------------------------
-
-As you might have noticed, Stormpath also has something called "Directories".
-When you created an Application in the previous step, Stormpath automatically
-created a new Directory for you.
-
-You can think of Directories in Stormpath as buckets of user accounts.  Every
-user account that you create on Stormpath will belong to a Directory.
-Directories hold unique groups of users.
-
-In most situations, your Stormpath Application will have a single Directory
-associated with it which is where all of your users will go.  In some
-situations, however, you might want to create additional Directories (or share a
-Directory between multiple Applications).
-
-Let's say you have two separate websites (*and therefore, two separate Stormpath
-Applications*): "dronewars.com" and "carswap.com".  If you wanted both of your
-websites to share the same user accounts (*so that if a user signs up on
-dronewars.com they can use their same login on carswap.com*), you could
-accomplish that by having a single Directory, and mapping it to both of your
-Stormpath Applications.
-
-Directories are useful for sharing and segmenting users in more complex
-authentication scenarios.
-
-You can read more about Stormpath Directories here:
-http://docs.stormpath.com/rest/product-guide/#directories
-
-.. note::
-    Stormpath has multiple types of "Directories".  There are: "Cloud
-    Directories", "Mirror Directories", "Facebook Directories" and "Google
-    Directories".
-
-    Cloud Directories hold *typical* user accounts.
-
-    Facebook and Google Directories allow you to automatically create Stormpath
-    user accounts for both Facebook and Google users (*using social login*).
-    Social login will be covered in detail later on.
-
-    Mirror Directories are used for syncing with `Active Directory`_ and
-    `LDAP`_ services (most people don't ever need these).
-
 
 Install the Package
 -------------------
@@ -118,20 +85,79 @@ package from `NPM`_.
 To install Express-Stormpath, you'll need ``npm``.  You can install the latest
 version of Express-Stormpath by running::
 
-    $ npm install express-stormpath
+    $ npm install --save express-stormpath
 
 If you'd like to upgrade to the latest version of Express-Stormpath (*maybe you
 have an old version installed*), you can run::
 
     $ npm update express-stormpath
 
-To force an upgrade.
-
 .. note::
     Express-Stormpath is currently *only* compatible with Express 4.x.
 
 
+
+
+Initialize Express-Stormpath
+----------------------------
+
+With the module installed, we can add it to our application. Here is a sample
+Express application, it shows the minimal code required to integrate Stormpath:
+
+ .. code-block:: javascript
+
+    var express = require('express');
+    var stormpath = require('express-stormpath');
+
+    var app = express();
+
+    app.use(stormpath.init(app, {
+      // Optional configuration options.
+    }));
+
+    app.listen(3000);
+
+    // Stormpath will let you know when it's ready to start authenticating users.
+    app.on('stormpath.ready', function () {
+        console.log('Stormpath Ready!');
+    });
+
+With this minimal configuration, our library will do the following:
+
+- Fetch your Stormpath Application and all the data about it's configuration and
+  account stores.
+
+- Attach the :ref:`default_features` to your express application, such as the
+  login page and registration page.
+
+- Hold any requests that require authentication, until Stormpath is ready.
+
+That's it, you're ready to go!  Try navigating to these URLs in your
+application:
+
+- http://localhost:3000/login
+- http://localhost:3000/register
+
+You should be able to register for an account, and log in.  The newly created
+account will be placed in the directory that is mapped to "My Application".
+
+.. note::
+
+    By default, we don't require email verification for new accounts, but we
+    highly recommend you use this workflow.  You can enable email verification
+    from the directory of your Stormpath Application.  You can do this from our
+    `Admin Console`_.
+
+There are many more features than login and registration, please continue to the
+next section to learn more!
+
+
+.. _Admin Console: https://api.stormpath.com/login
+.. _Application Resource: https://docs.stormpath.com/rest/product-guide/latest/reference.html#application
 .. _Active Directory: http://en.wikipedia.org/wiki/Active_Directory
+.. _Directory Resource: https://docs.stormpath.com/rest/product-guide/latest/reference.html#directory
 .. _LDAP: http://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol
 .. _Express-Stormpath: https://www.npmjs.org/package/express-stormpath
+.. _Modeling Your User Base: https://docs.stormpath.com/rest/product-guide/latest/accnt_mgmt.html#modeling-your-user-base
 .. _NPM: https://www.npmjs.org/
+.. _Setting up Development and Production Environments: https://docs.stormpath.com/guides/dev-test-prod-environments/

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -5,8 +5,8 @@ Setup
 =====
 
 This section walks you through the basic setup for Express-Stormpath, by the end
-of this page you'll have setup login and registration features for your Express
-application!
+of this page you'll have setup the login and registration features for your
+Express application!
 
 Create a Stormpath Account
 --------------------------
@@ -117,11 +117,11 @@ Express application, it shows the minimal code required to integrate Stormpath:
       // Optional configuration options.
     }));
 
-    app.listen(3000, function (err) {
-      if (err) {
-        return console.error(err);
-      }
-      console.log('Server running on http://localhost:3000/');
+    app.listen(3000);
+
+    // Stormpath will let you know when it's ready to start authenticating users.
+    app.on('stormpath.ready', function () {
+      console.log('Stormpath Ready!');
     });
 
 With this minimal configuration, our library will do the following:

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -153,12 +153,28 @@ There are many more features than login and registration, please continue to the
 next section to learn more!
 
 
+Example Applications
+--------------------
+
+Looking for some example applications?  We provide the following examples
+applications to get you up and running quickly.  They show you how to setup
+Stormpath, and implement a profile page for the logged-in user:
+
+- `Express-Stormpath Example Project`_
+
+- `Stormpath Angular + Express Fullstack Sample Project`_
+
+- `Stormpath React + Express Fullstack Example Project`_
+
 .. _Admin Console: https://api.stormpath.com/login
 .. _Application Resource: https://docs.stormpath.com/rest/product-guide/latest/reference.html#application
 .. _Active Directory: http://en.wikipedia.org/wiki/Active_Directory
 .. _Directory Resource: https://docs.stormpath.com/rest/product-guide/latest/reference.html#directory
+.. _Express-Stormpath Example Project: https://github.com/stormpath/express-stormpath-sample-project
 .. _LDAP: http://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol
 .. _Express-Stormpath: https://www.npmjs.org/package/express-stormpath
 .. _Modeling Your User Base: https://docs.stormpath.com/rest/product-guide/latest/accnt_mgmt.html#modeling-your-user-base
 .. _NPM: https://www.npmjs.org/
 .. _Setting up Development and Production Environments: https://docs.stormpath.com/guides/dev-test-prod-environments/
+.. _Stormpath Angular + Express Fullstack Sample Project: https://github.com/stormpath/express-stormpath-angular-sample-project
+.. _Stormpath React + Express Fullstack Example Project: https://github.com/stormpath/stormpath-express-react-example


### PR DESCRIPTION
Previously, the steps required to get started with this module were split between the “Setup” page and the “Configuration” page.

This PR fixes that strangeness.  The “Setup” page is now quickstart-like, and the “Configuration” page has more in-depth information about how to configure the library, and what the defaults are.