### PR TITLE
Use JwtAuthenticator for Bearer authentication requests

### DIFF
--- a/lib/middleware/api-authentication-required.js
+++ b/lib/middleware/api-authentication-required.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var helpers = require('../helpers');
-
+var stormpath = require('stormpath');
 /**
  * Assert that a user has specified valid API credentials before allowing them
  * to continue.  If the user's credentials are invalid, a 401 will be returned
@@ -57,5 +57,18 @@ module.exports = function (req, res, next) {
     });
   }
 
-  application.authenticateApiRequest({ request: req }, handleAuthResponse);
+  var authHeader = req.headers.authorization;
+
+  var token = authHeader && authHeader.match(/Bearer .+/) ? authHeader.split('Bearer ')[1] : '';
+
+  var isBasic = req.headers.authorization && req.headers.authorization.match(/Basic .+/);
+
+  if (token) {
+    return new stormpath.JwtAuthenticator(application).authenticate(token, handleAuthResponse);
+  } else if (isBasic) {
+    return application.authenticateApiRequest({ request: req }, handleAuthResponse);
+  } else {
+    res.status(401).send('Unauthorized');
+  }
+
 };


### PR DESCRIPTION
Fixes #261 

It's now possible to use `stormpath.apiAuthenticationRequired` with the `stormpath` validation strategy.

To verify, create a simple application that uses the `apiAuthenticationRequired` middleware, with the `stormpath` validation option:

```javascript
var express = require('express');
var stormpath = require('express-stormpath');

var app = express();

app.use(stormpath.init(app, {
  web: {
    oauth2: {
      password: {
        validationStrategy: 'stormpath'
      }
    }
  }
}));

app.get('/', stormpath.apiAuthenticationRequired, function (req, res) {
  res.json({'hello': req.user.fullName});
});

app.listen(3000);
```

Then get an access token:

> curl -X POST -d grant_type=password -d username=XXX -d password=YYY http://localhost:3000/oauth/token

And use that access token to authenticate with the server:

> curl -H "Authorization: Bearer TOKEN" http://localhost:3000/

You should get the "hello" message.  Now, go into the Admin Console and delete this access token from the account's OAuth Tokens view.

Now, try to use the token again for authentication.  This time you should get a 401 response.