### PR TITLE
Corrections to produces: JSON default, send 406 if no match

### DIFF
--- a/lib/helpers/handle-accept-request.js
+++ b/lib/helpers/handle-accept-request.js
@@ -44,7 +44,10 @@ function handleAcceptRequest(req, res, handlers, fallbackHandler) {
   // always override with the SPA handler if SPA is enabled.
   var handler;
 
-  allowedResponseTypes.some(function (contentType) {
+  accepted.some(function (contentType) {
+    if (allowedResponseTypes.indexOf(contentType) === -1) {
+      return false;
+    }
     if (config.web.spa.enabled && contentType === 'text/html') {
       handler = spaResponseHandler(config);
       return true;

--- a/lib/helpers/handle-accept-request.js
+++ b/lib/helpers/handle-accept-request.js
@@ -30,11 +30,15 @@ function handleAcceptRequest(req, res, handlers, fallbackHandler) {
   // Our default response is HTML, if the client does not specify something more
   // specific.  As such, map the wildcard type to html.
   accepted = accepted.map(function (contentType) {
-    return contentType === '*/*' ? 'text/html' : contentType;
+    return contentType === '*/*' ? produces[0] : contentType;
   });
 
   // Of the accepted types, find the ones that are allowed by the configuration.
   var allowedResponseTypes = _.intersection(produces, accepted);
+
+  if (!allowedResponseTypes.length) {
+    return res.status(406).end();
+  }
 
   // Of the allowed response types, find the first handler that matches. But
   // always override with the SPA handler if SPA is enabled.

--- a/test/controllers/test-email-verification.js
+++ b/test/controllers/test-email-verification.js
@@ -11,7 +11,8 @@ var SpaRootFixture = require('../fixtures/spa-root-fixture');
 function requestVerifyPage(app, sptoken) {
   var config = app.get('stormpathConfig');
   return request(app)
-    .get(config.web.verifyEmail.uri + (sptoken ? ('?sptoken=' + sptoken) : ''));
+    .get(config.web.verifyEmail.uri + (sptoken ? ('?sptoken=' + sptoken) : ''))
+    .set('Accept', 'text/html');
 }
 
 function assertVerifyFormExists(res) {
@@ -71,6 +72,7 @@ describe('email verification', function () {
     var config = expressApp.get('stormpathConfig');
     request(expressApp)
       .post('/register')
+      .set('Accept', 'text/html')
       .type('form')
       .send(helpers.newUser())
       .expect(302)
@@ -84,6 +86,7 @@ describe('email verification', function () {
     var config = expressApp.get('stormpathConfig');
     request(expressApp)
       .post(config.web.verifyEmail.uri)
+      .set('Accept', 'text/html')
       .type('form')
       .send({ email: helpers.newUser().email })
       .expect(302)
@@ -99,6 +102,7 @@ describe('email verification', function () {
           var config = expressApp.get('stormpathConfig');
           request(expressApp)
             .post(config.web.verifyEmail.uri)
+            .set('Accept', 'text/html')
             .type('form')
             .send({ email: uuid() })
             .expect(200)
@@ -113,6 +117,7 @@ describe('email verification', function () {
           var config = expressApp.get('stormpathConfig');
           request(expressApp)
             .post(config.web.verifyEmail.uri)
+            .set('Accept', 'text/html')
             .send({ login: uuid() })
             .set('Accept', 'application/json')
             .expect(200, '', done);
@@ -126,6 +131,7 @@ describe('email verification', function () {
           var config = expressApp.get('stormpathConfig');
           request(expressApp)
             .post(config.web.verifyEmail.uri)
+            .set('Accept', 'text/html')
             .set('Accept', 'application/json')
             .expect(400, '{"status":400,"message":"login property cannot be null, empty, or blank."}', done);
         });

--- a/test/controllers/test-forgot-password.js
+++ b/test/controllers/test-forgot-password.js
@@ -78,6 +78,7 @@ describe('forgotPassword', function () {
       var config = app.get('stormpathConfig');
       request(app)
         .get('/forgot')
+        .set('Accept', 'text/html')
         .expect(200)
         .end(function (err, res) {
           if (err) {
@@ -108,6 +109,7 @@ describe('forgotPassword', function () {
     app.on('stormpath.ready', function () {
       request(app)
         .post('/forgot')
+        .set('Accept', 'text/html')
         .type('form')
         .send({ email: 'not a real email' })
         .expect(200)
@@ -137,6 +139,7 @@ describe('forgotPassword', function () {
     app.on('stormpath.ready', function () {
       request(app)
         .get('/forgot?status=invalid_sptoken')
+        .set('Accept', 'text/html')
         .expect(200)
         .end(function (err, res) {
           assertInvalidSpTokenMessage(res);
@@ -161,6 +164,7 @@ describe('forgotPassword', function () {
       var config = app.get('stormpathConfig');
       request(app)
         .post('/forgot')
+        .set('Accept', 'text/html')
         .type('form')
         .send({ email: uuid.v4() + '@stormpath.com' })
         .expect('Location', config.web.forgotPassword.nextUri)

--- a/test/controllers/test-login.js
+++ b/test/controllers/test-login.js
@@ -55,6 +55,7 @@ describe('login', function () {
 
     request(defaultExpressApp)
       .get('/login')
+      .set('Accept', 'text/html')
       .expect(200)
       .end(function (err, res) {
         var $ = cheerio.load(res.text);
@@ -164,6 +165,7 @@ describe('login', function () {
 
     request(defaultExpressApp)
       .get(protectedUri)
+      .set('Accept', 'text/html')
       .expect(302)
       .expect('Location', '/login?next=' + encodeURIComponent(protectedUri))
       .end(done);
@@ -176,6 +178,7 @@ describe('login', function () {
     var nextUri = uuid.v4();
     request(defaultExpressApp)
       .get('/login?next=' + encodeURIComponent(nextUri))
+      .set('Accept', 'text/html')
       .expect(200)
       .end(function (err, res) {
         var $ = cheerio.load(res.text);
@@ -192,6 +195,7 @@ describe('login', function () {
     var nextUri = 'http://stormpath.com/foo';
     request(defaultExpressApp)
       .post('/login?next=' + encodeURIComponent(nextUri))
+      .set('Accept', 'text/html')
       .send({ login: username, password: password })
       .expect(302)
       .expect('Location', '/foo')
@@ -204,6 +208,7 @@ describe('login', function () {
     var nextUri = uuid.v4();
     request(defaultExpressApp)
       .post('/login?next=' + encodeURIComponent(nextUri))
+      .set('Accept', 'text/html')
       .send({ login: username, password: password })
       .expect(302)
       .expect('Location', nextUri)
@@ -215,12 +220,14 @@ describe('login', function () {
       function (cb) {
         request(alternateUrlExpressApp)
           .get('/newlogin')
+          .set('Accept', 'text/html')
           .expect(200)
           .end(cb);
       },
       function (cb) {
         request(alternateUrlExpressApp)
           .get('/login')
+          .set('Accept', 'text/html')
           .expect(404)
           .end(cb);
       }

--- a/test/controllers/test-logout.js
+++ b/test/controllers/test-logout.js
@@ -64,6 +64,7 @@ describe('logout', function () {
   it('should bind to /logout by default', function (done) {
     request(app)
       .post(config.web.logout.uri)
+      .set('Accept', 'text/html')
       .expect(302)
       .end(done);
   });
@@ -103,6 +104,7 @@ describe('logout', function () {
   it('should follow the next param if present', function (done) {
     request(app)
       .post(config.web.logout.uri + '?next=/goodbye')
+      .set('Accept', 'text/html')
       .expect(302)
       .expect('Location', '/goodbye')
       .end(done);

--- a/test/controllers/test-register.js
+++ b/test/controllers/test-register.js
@@ -414,6 +414,7 @@ describe('register', function () {
     it('should bind to that uri', function (done) {
       request(app)
         .get('/customRegistrationUri')
+        .set('Accept', 'text/html')
         .expect(200)
         .end(assertDefaultFormResponse(done));
     });

--- a/test/controllers/test-reset-password.js
+++ b/test/controllers/test-reset-password.js
@@ -11,7 +11,8 @@ var SpaRootFixture = require('../fixtures/spa-root-fixture');
 function requestResetPage(app, sptoken) {
   var config = app.get('stormpathConfig');
   return request(app)
-    .get(config.web.changePassword.uri + (sptoken ? ('?sptoken=' + sptoken) : ''));
+    .get(config.web.changePassword.uri + (sptoken ? ('?sptoken=' + sptoken) : ''))
+    .set('Accept', 'text/html');
 }
 
 function assertResetFormExists(res) {
@@ -186,6 +187,7 @@ describe('resetPassword', function () {
       var config = app.get('stormpathConfig');
       request(app)
         .post(config.web.changePassword.uri)
+        .set('Accept', 'text/html')
         .type('form')
         .send({
           password: 'a',
@@ -216,6 +218,7 @@ describe('resetPassword', function () {
       var config = app.get('stormpathConfig');
       request(app)
         .post(config.web.changePassword.uri)
+        .set('Accept', 'text/html')
         .type('form')
         .send({
           password: 'a',
@@ -246,6 +249,7 @@ describe('resetPassword', function () {
       var config = app.get('stormpathConfig');
       request(app)
         .post(config.web.changePassword.uri)
+        .set('Accept', 'text/html')
         .type('form')
         .send({
           password: 'a',
@@ -275,6 +279,7 @@ describe('resetPassword', function () {
       var config = app.get('stormpathConfig');
       request(app)
         .post(config.web.changePassword.uri)
+        .set('Accept', 'text/html')
         .type('form')
         .send({
           password: newPassword,
@@ -313,6 +318,7 @@ describe('resetPassword', function () {
       var config = app.get('stormpathConfig');
       request(app)
         .post(config.web.changePassword.uri)
+        .set('Accept', 'text/html')
         .type('form')
         .send({ sptoken: passwordResetToken })
         .expect(302)

--- a/test/fixtures/produces-fixture.js
+++ b/test/fixtures/produces-fixture.js
@@ -35,6 +35,9 @@ ProducesFixture.prototype.getEndpointWithAccept = function getEndpointWithAccept
     .get(stormpathConfig.web.login.uri)
     .set('Accept', acceptString);
 };
+ProducesFixture.prototype.requestAsBrowser = function requestAsBrowser() {
+  return this.getEndpointWithAccept('text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8');
+};
 ProducesFixture.prototype.requestAsJson = function requestAsJson() {
   return this.getEndpointWithAccept('application/json');
 };

--- a/test/fixtures/produces-fixture.js
+++ b/test/fixtures/produces-fixture.js
@@ -41,6 +41,12 @@ ProducesFixture.prototype.requestAsJson = function requestAsJson() {
 ProducesFixture.prototype.requestAsHtml = function requestAsHtml() {
   return this.getEndpointWithAccept('text/html');
 };
+ProducesFixture.prototype.requestWithoutAcceptHeader = function requestWithoutAcceptHeader() {
+  var stormpathConfig = this.expressApp.get('stormpathConfig');
+
+  return request(this.expressApp)
+    .get(stormpathConfig.web.login.uri);
+};
 ProducesFixture.prototype.assertHtmlResponse = function assertHtmlResponse(done) {
   return function (err, res) {
     if (err) {
@@ -59,12 +65,12 @@ ProducesFixture.prototype.assertJsonResponse = function assertJsonResponse(done)
     done();
   };
 };
-ProducesFixture.prototype.assert404Response = function assert404Response(done) {
+ProducesFixture.prototype.assert406Response = function assert406Response(done) {
   return function (err, res) {
     if (err) {
       return done(err);
     }
-    assert.equal(res.status, 404);
+    assert.equal(res.status, 406);
     done();
   };
 };

--- a/test/handlers/test-post-registration-handler.js
+++ b/test/handlers/test-post-registration-handler.js
@@ -178,6 +178,7 @@ describe('Post-Registration Handler', function () {
       preparePostRegistrationExpansionTestFixture(stormpathApplication, function (fixture) {
         request(fixture.expressApp)
           .post('/register')
+          .set('Accept', 'text/html')
           .send(fixture.newAccountObject)
           .expect(200)
           .end(function (err, res) {
@@ -196,6 +197,7 @@ describe('Post-Registration Handler', function () {
       preparePostRegistrationPassThroughTestFixture(stormpathApplication, function (fixture) {
         request(fixture.expressApp)
           .post('/register')
+          .set('Accept', 'text/html')
           .send(fixture.newAccountObject)
           .expect(302)
           .end(function (err) {
@@ -214,6 +216,7 @@ describe('Post-Registration Handler', function () {
       preparePostRegistrationAutoLoginTestFixture(stormpathApplication, function (fixture) {
         request(fixture.expressApp)
           .post('/register')
+          .set('Accept', 'text/html')
           .send(fixture.newAccountObject)
           .expect('Set-Cookie', /access_token=[^;]+/)
           .expect(302)

--- a/test/helpers/test-get-user.js
+++ b/test/helpers/test-get-user.js
@@ -259,6 +259,7 @@ describe('getUser', function () {
       function (callback) {
         agent
           .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: accountData.email,
             password: accountData.password
@@ -311,6 +312,7 @@ describe('getUser', function () {
       function (callback) {
         agent
           .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: accountData.email,
             password: accountData.password
@@ -369,6 +371,7 @@ describe('getUser', function () {
       function (callback) {
         agent
           .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: accountData.email,
             password: accountData.password
@@ -429,6 +432,7 @@ describe('getUser', function () {
       function (callback) {
         agent
           .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: accountData.email,
             password: accountData.password
@@ -483,6 +487,7 @@ describe('getUser', function () {
         function (callback) {
           agent
             .post('/login')
+            .set('Accept', 'text/html')
             .send({
               login: accountData.email,
               password: accountData.password
@@ -533,6 +538,7 @@ describe('getUser', function () {
       function (callback) {
         agent
           .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: accountData.email,
             password: accountData.password
@@ -629,6 +635,7 @@ describe('getUser', function () {
       function (callback) {
         agent
           .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: accountData.email,
             password: accountData.password
@@ -684,6 +691,7 @@ describe('getUser', function () {
       function (callback) {
         agent
           .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: accountData.email,
             password: accountData.password
@@ -734,6 +742,7 @@ describe('getUser', function () {
       function (callback) {
         agent
           .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: accountData.email,
             password: accountData.password
@@ -790,6 +799,7 @@ describe('getUser', function () {
       function (callback) {
         agent
           .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: accountData.email,
             password: accountData.password

--- a/test/produces.js
+++ b/test/produces.js
@@ -38,6 +38,11 @@ describe('produces option', function () {
         fixture.requestAsJson().end(fixture.assertJsonResponse(done));
       });
     });
+    describe('and Accept is a browser default', function () {
+      it('should respond with HTML', function (done) {
+        fixture.requestAsBrowser().end(fixture.assertHtmlResponse(done));
+      });
+    });
     describe('and request has no Accept header', function () {
       it('should respond with JSON (the first item in the produces list)', function (done) {
         fixture.requestWithoutAcceptHeader().end(fixture.assertJsonResponse(done));
@@ -87,6 +92,12 @@ describe('produces option', function () {
     describe('and request is Accept: application/json', function () {
       it('should respond with 406', function (done) {
         fixture.requestAsJson().end(fixture.assert406Response(done));
+      });
+    });
+
+    describe('and Accept is a browser default', function () {
+      it('should respond with HTML', function (done) {
+        fixture.requestAsBrowser().end(fixture.assertHtmlResponse(done));
       });
     });
 

--- a/test/produces.js
+++ b/test/produces.js
@@ -38,6 +38,11 @@ describe('produces option', function () {
         fixture.requestAsJson().end(fixture.assertJsonResponse(done));
       });
     });
+    describe('and request has no Accept header', function () {
+      it('should respond with JSON (the first item in the produces list)', function (done) {
+        fixture.requestWithoutAcceptHeader().end(fixture.assertJsonResponse(done));
+      });
+    });
   });
 
   describe('if configured as [\'application/json\']', function () {
@@ -48,14 +53,20 @@ describe('produces option', function () {
     });
 
     describe('and request is Accept: text/html', function () {
-      it('should respond with 404', function (done) {
-        fixture.requestAsHtml().end(fixture.assert404Response(done));
+      it('should respond with 406', function (done) {
+        fixture.requestAsHtml().end(fixture.assert406Response(done));
       });
     });
 
     describe('and request is Accept: application/json', function () {
       it('should respond with JSON', function (done) {
         fixture.requestAsJson().end(fixture.assertJsonResponse(done));
+      });
+    });
+
+    describe('and request has no Accept header', function () {
+      it('should respond with JSON', function (done) {
+        fixture.requestWithoutAcceptHeader().end(fixture.assertJsonResponse(done));
       });
     });
   });
@@ -72,9 +83,16 @@ describe('produces option', function () {
         fixture.requestAsHtml().end(fixture.assertHtmlResponse(done));
       });
     });
+
     describe('and request is Accept: application/json', function () {
-      it('should respond with 404', function (done) {
-        fixture.requestAsJson().end(fixture.assert404Response(done));
+      it('should respond with 406', function (done) {
+        fixture.requestAsJson().end(fixture.assert406Response(done));
+      });
+    });
+
+    describe('and request has no Accept header', function () {
+      it('should respond with HTML', function (done) {
+        fixture.requestAsHtml().end(fixture.assertHtmlResponse(done));
       });
     });
   });


### PR DESCRIPTION
Fixes #384 

We've finalized the spec for our "produces" option and how we handle content-type negotiation.  You can see the details [here](https://github.com/stormpath/stormpath-framework-spec/blob/master/requests.md#accept-header).

This commit makes two change to bring this library up to date:
* The default response type is JSON if the client does not specify anything.  As such, some of our tests had to be more specific and request text/html when needed.
* We now return 406 if the client asks for an unsupported request type.

The first item is technically a breaking change, for anyone that was relying on a default HTML response when not specifying an Accept preference.  But I don't want to roll up to 4.x for this, so we'll just call it out in the changelog.  I'll be really surprised if anyone is relying on this behavior.