### PR TITLE
Logger fixes

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -248,13 +248,13 @@ Logging
 By default, this library will create a `Winston`_ logger and use this for
 logging error messages to standard output.
 
-While actively developing your application, you may want to include the ``info``
-level for debugging purposes:
+While actively developing your application, you may want to increase to the
+``info`` level for debugging purposes:
 
 .. code-block:: javascript
 
     app.use(stormpath.init(app, {
-      debug: 'info, error'
+      debug: 'info'
     }));
 
 If you want to supply your own Winston logger, you can do that as well:

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -27,19 +27,20 @@ var userAgent = 'stormpath-express/' + version + ' ' + 'express/' + expressVersi
 function initClient(app, opts) {
   opts.userAgent = userAgent;
 
-  var logger = app.get('stormpathLogger');
+  var logger = opts.logger;
 
   if (!logger) {
     logger = new winston.Logger({
       transports: [
         new winston.transports.Console({
           colorize: true,
-          level: opts.debug ? 'info' : 'error'
+          level: opts.debug || 'error'
         })
       ]
     });
-    app.set('stormpathLogger', logger);
   }
+
+  app.set('stormpathLogger', logger);
 
   var client = require('./client')(opts);
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -192,3 +192,13 @@ module.exports.destroyApplication = function (application, callback) {
     });
   });
 };
+
+/**
+ * A logger implementation that does not do anything, useful for tests where you
+ * want to silence the default logger.
+ * @type {Object}
+ */
+module.exports.noOpLogger = {
+  info: function () {},
+  error: function () {}
+};


### PR DESCRIPTION
Fixes #383 

Custom loggers were not being used, and only one log level string can be used.

Cleaning up stormpath.init() tests while I’m at it.