### PR TITLE
Fix broken local validaion

### DIFF
--- a/lib/middleware/api-authentication-required.js
+++ b/lib/middleware/api-authentication-required.js
@@ -64,7 +64,11 @@ module.exports = function (req, res, next) {
   var isBasic = req.headers.authorization && req.headers.authorization.match(/Basic .+/);
 
   if (token) {
-    return new stormpath.JwtAuthenticator(application).authenticate(token, handleAuthResponse);
+    var authenticator = new stormpath.JwtAuthenticator(application).authenticate(token, handleAuthResponse);
+    if (config.web.oauth2.password.validationStrategy === 'local') {
+      authenticator.withLocalValidation();
+    }
+    return authenticator;
   } else if (isBasic) {
     return application.authenticateApiRequest({ request: req }, handleAuthResponse);
   } else {

--- a/lib/middleware/api-authentication-required.js
+++ b/lib/middleware/api-authentication-required.js
@@ -64,11 +64,11 @@ module.exports = function (req, res, next) {
   var isBasic = req.headers.authorization && req.headers.authorization.match(/Basic .+/);
 
   if (token) {
-    var authenticator = new stormpath.JwtAuthenticator(application).authenticate(token, handleAuthResponse);
+    var authenticator = new stormpath.JwtAuthenticator(application);
     if (config.web.oauth2.password.validationStrategy === 'local') {
       authenticator.withLocalValidation();
     }
-    return authenticator;
+    return authenticator.authenticate(token, handleAuthResponse);
   } else if (isBasic) {
     return application.authenticateApiRequest({ request: req }, handleAuthResponse);
   } else {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "parse-iso-duration": "^1.0.0",
     "qs": "^6.0.2",
     "request": "^2.63.0",
-    "stormpath": "^0.18.0",
+    "stormpath": "^0.18.2",
     "stormpath-config": "0.0.22",
     "utils-merge": "^1.0.0",
     "uuid": "^2.0.1",


### PR DESCRIPTION
3.1.0 did not carry over the local validation option to `authenticateApiRequest`, this fixes that problem.