### PR TITLE
more change-password fixes

### DIFF
--- a/lib/controllers/change-password.js
+++ b/lib/controllers/change-password.js
@@ -42,6 +42,11 @@ module.exports = function (req, res, next) {
           return helpers.writeJsonError(res, err);
         }
 
+        // For GET requests, respond with 200 OK if the token is valid.
+        if (req.method === 'GET') {
+          return res.end();
+        }
+
         result.password = req.body.password;
 
         return result.save(function (err) {


### PR DESCRIPTION
Another fix for #385.  In #388 we fixed the invalid token case but broke the valid token case in ef8822a13ffb7965b2e308cc37bc3984db766967.

I've added more tests to ensure that we don't break this API in the future, we also need to look at the email verification API to ensure that it is working correctly for JSON and that it has tests.