### PR TITLE
Pass complete path when delegating to view engine

### DIFF
--- a/lib/helpers/render.js
+++ b/lib/helpers/render.js
@@ -57,7 +57,7 @@ module.exports = function (req, res, view, options) {
     res.send(renderJade(view, options));
   } else if (extension) {
     // Delegate to the view engine.
-    res.render(filename, options);
+    res.render(view, options);
   } else {
     throw new Error('Unexpected view option: "' + view + '".  Please see documentation for express-stormpath');
   }


### PR DESCRIPTION
Fixes bug for when not using jade and template has an extra `.` in its name.  For example, if view is `foo.bar.ejs`, then:
* it calls `res.render('foo.bar')`
* express then strips the `extname` and thinks the template is of type `bar`

I think it's best just to pass the direct value into express, and let it handle everything.  Thoughts?