### PR TITLE
Typo: Successfuly => Successfully

### DIFF
--- a/lib/views/login.jade
+++ b/lib/views/login.jade
@@ -37,7 +37,7 @@ block body
                     You may now login.
                 if status === 'reset'
                   span.
-                    Password Reset Successfuly
+                    Password Reset Successfully
                   p.
                     You can now login with your new password.
                   br


### PR DESCRIPTION
There's a typo in the message once the password has been reset: `Successfuly` => `Successfully`

### How to review

Run the [express-stormpath-sample-project](https://github.com/stormpath/express-stormpath-sample-project) and reset your password. Once the password is reset, verify that you see this message:

> Password Reset Successfully