### PR TITLE
autoLogin support for client-side apps

### DIFF
--- a/lib/controllers/change-password.js
+++ b/lib/controllers/change-password.js
@@ -55,7 +55,7 @@ module.exports = function (req, res, next) {
             return helpers.writeJsonError(res, err);
           }
 
-          res.end();
+          res.json(result);
         });
       });
     },


### PR DESCRIPTION
When a client-side app like react-stormpath does a POST to /change, the only way it can then do an auto-login is to know the account username and password and execute a /login, then a redirect.  The client knows password (because of the change password form), but does not know the username, because the user got to the change password form via an email link.  But if the POST to /change returns the account (which is has), then client can get at the username.

This change was made specifically to support autoLogin capability in react-stormpath.