### PR TITLE
Fix groupsRequired middleware so that it handles Accept header

### DIFF
--- a/lib/helpers/write-json-error.js
+++ b/lib/helpers/write-json-error.js
@@ -8,8 +8,8 @@
  * @param {Object} res - Express http response.
  * @param {Object} err - An error object.
  */
-function writeJsonError(res, err) {
-  var status = err.status || err.statusCode || 400;
+function writeJsonError(res, err, statusCode) {
+  var status = err.status || err.statusCode || statusCode || 400;
   var message = 'Unknown error. Please contact support.';
 
   if (err) {

--- a/lib/middleware/groups-required.js
+++ b/lib/middleware/groups-required.js
@@ -9,7 +9,7 @@ var helpers = require('../helpers');
  * shown an unauthorized page letting them know they do not have the required
  * permissions.
  *
- * @param {String[]} assertGroups - List of groups to assert membership for. Groups
+ * @param {String[]} groups - List of groups to assert membership for. Groups
  *   must be specified by group name.
  * @param {Boolean} [all=true] - Whether membership is required in one group or all.
  *
@@ -17,11 +17,12 @@ var helpers = require('../helpers');
  *   group membership, and only allows the user to continue if the assertions
  *   are true.
  */
-module.exports = function (assertGroups, all) {
+module.exports = function (groups, all) {
   all = all === false ? false : true;
 
   return function (req, res, next) {
     var config = req.app.get('stormpathConfig');
+    var logger = req.app.get('stormpathLogger');
 
     function redirectToLoginPage() {
       var url = config.web.login.uri + '?next=' + encodeURIComponent(req.originalUrl);
@@ -30,10 +31,11 @@ module.exports = function (assertGroups, all) {
 
     function isUserInGroups(callback) {
       var isInGroup = false;
-      var done = assertGroups.length;
+      var done = groups.length;
 
       req.user.getGroups(function (err, userGroups) {
         if (err) {
+          logger.info('Could not fetch user ' + req.user.email + '\'s groups.');
           return callback(null, false);
         }
 
@@ -41,7 +43,7 @@ module.exports = function (assertGroups, all) {
         // whether or not it's one of the required groups.
         userGroups.each(
           function (group, iterateNext) {
-            if (assertGroups.indexOf(group.name) > -1) {
+            if (groups.indexOf(group.name) > -1) {
               if (!all || --done === 0) {
                 isInGroup = true;
               }
@@ -55,38 +57,42 @@ module.exports = function (assertGroups, all) {
       });
     }
 
-    helpers.handleAcceptRequest(req, res, {
-      'application/json': function () {
-        if (!req.user) {
-          return helpers.writeJsonError(res, new Error('You are not authenticated. Please log in to access this resource.'), 401);
-        }
-
-        isUserInGroups(function (err, isInGroup) {
-          if (err) {
-            return helpers.writeJsonError(res, new Error('An internal error occurred. Please contact support.'), 500);
-          }
-
-          if (!isInGroup) {
-            return helpers.writeJsonError(res, new Error('You do not have sufficient permissions to access this resource.'), 403);
-          }
-
-          next();
-        });
-      },
-      'text/html': function () {
-        if (!req.user) {
-          return redirectToLoginPage();
-        }
-
-        isUserInGroups(function (err, isInGroup) {
-          if (err || !isInGroup) {
-            res.status(403);
-            return helpers.render(req, res, 'unauthorized');
-          }
-
-          next();
-        });
+    function handleJsonRequest() {
+      if (!req.user) {
+        return helpers.writeJsonError(res, new Error('You are not authenticated. Please log in to access this resource.'), 401);
       }
-    }, redirectToLoginPage);
+
+      isUserInGroups(function (err, isInGroup) {
+        if (err) {
+          return helpers.writeJsonError(res, new Error('An internal error occurred. Please contact support.'), 500);
+        }
+
+        if (!isInGroup) {
+          return helpers.writeJsonError(res, new Error('You do not have sufficient permissions to access this resource.'), 403);
+        }
+
+        next();
+      });
+    }
+
+    function handleTextHtmlRequest() {
+      if (!req.user) {
+        return redirectToLoginPage();
+      }
+
+      isUserInGroups(function (err, isInGroup) {
+        if (err || !isInGroup) {
+          res.status(403);
+          return helpers.render(req, res, 'unauthorized');
+        }
+
+        next();
+      });
+    }
+
+    helpers.handleAcceptRequest(req, res, {
+      'text/html': handleTextHtmlRequest,
+      'application/json': handleJsonRequest
+    }, handleTextHtmlRequest);
   };
 };

--- a/lib/middleware/groups-required.js
+++ b/lib/middleware/groups-required.js
@@ -4,63 +4,89 @@ var helpers = require('../helpers');
 
 /**
  * Assert that a user is a member of one or more groups before allowing the user
- * to continue.  If the user is not logged in, they will be redirected to the
- * login page.  If the user does not meet the group requirements, they will be
+ * to continue. If the user is not logged in, they will be redirected to the
+ * login page. If the user does not meet the group requirements, they will be
  * shown an unauthorized page letting them know they do not have the required
  * permissions.
  *
- * @param {String[]} groups - A list of groups to assert membership in.  Groups
+ * @param {String[]} assertGroups - List of groups to assert membership for. Groups
  *   must be specified by group name.
- * @param {Boolean} [all=true] - Should we assert the user is a member of all groups,
- *   or just one?
+ * @param {Boolean} [all=true] - Whether membership is required in one group or all.
  *
  * @returns {Function} Returns an express middleware which asserts a user's
  *   group membership, and only allows the user to continue if the assertions
  *   are true.
  */
-module.exports = function (groups, all) {
+module.exports = function (assertGroups, all) {
   all = all === false ? false : true;
 
   return function (req, res, next) {
     var config = req.app.get('stormpathConfig');
-    var logger = req.app.get('stormpathLogger');
-    var view = 'unauthorized';
 
-    if (!req.user) {
+    function redirectToLoginPage() {
       var url = config.web.login.uri + '?next=' + encodeURIComponent(req.originalUrl);
       return res.redirect(302, url);
     }
 
-    // If this user must be a member of all groups, we'll ensure that is the
-    // case.
-    var done = groups.length;
-    var safe = false;
+    function isUserInGroups(callback) {
+      var isInGroup = false;
+      var done = assertGroups.length;
 
-    req.user.getGroups(function (err, grps) {
-      if (err) {
-        logger.info('Could not fetch user ' + req.user.email + '\'s groups.');
-        return helpers.render(req, res, view);
-      }
+      req.user.getGroups(function (err, userGroups) {
+        if (err) {
+          return callback(null, false);
+        }
 
-      // Iterate through each group on the user's account, checking to see
-      // whether or not it's one of the required groups.
-      grps.each(function (group, c) {
-        if (groups.indexOf(group.name) > -1) {
-          if (!all || --done === 0) {
-            safe = true;
-            next();
+        // Iterate through each group on the user's account, checking to see
+        // whether or not it's one of the required groups.
+        userGroups.each(
+          function (group, iterateNext) {
+            if (assertGroups.indexOf(group.name) > -1) {
+              if (!all || --done === 0) {
+                isInGroup = true;
+              }
+            }
+            iterateNext();
+          },
+          function () {
+            callback(null, isInGroup);
           }
-        }
-        c();
-      },
-      // If we get here, it means the user didn't meet the requirements,
-      // so we'll send them to the login page with the ?next querystring set.
-      function () {
-        if (!safe) {
-          logger.info('User ' + req.user.email + ' attempted to access a protected endpoint but did not meet the group check requirements.');
-          helpers.render(req, res, view);
-        }
+        );
       });
-    });
+    }
+
+    helpers.handleAcceptRequest(req, res, {
+      'application/json': function () {
+        if (!req.user) {
+          return helpers.writeJsonError(res, new Error('You are not authenticated. Please log in to access this resource.'), 401);
+        }
+
+        isUserInGroups(function (err, isInGroup) {
+          if (err) {
+            return helpers.writeJsonError(res, new Error('An internal error occurred. Please contact support.'), 500);
+          }
+
+          if (!isInGroup) {
+            return helpers.writeJsonError(res, new Error('You do not have sufficient permissions to access this resource.'), 403);
+          }
+
+          next();
+        });
+      },
+      'text/html': function () {
+        if (!req.user) {
+          return redirectToLoginPage();
+        }
+
+        isUserInGroups(function (err, isInGroup) {
+          if (err || !isInGroup) {
+            res.status(403);
+            return helpers.render(req, res, 'unauthorized');
+          }
+
+          next();
+        });
+      }
+    }, redirectToLoginPage);
   };
 };

--- a/test/middlewares/test-groups-required.js
+++ b/test/middlewares/test-groups-required.js
@@ -7,18 +7,38 @@ var uuid = require('uuid');
 var helpers = require('../helpers');
 var stormpath = require('../../index');
 
+function createExpressTestApp(applicationHref, groupsToAssert, assertAll) {
+  var app = helpers.createStormpathExpressApp({
+    application: {
+      href: applicationHref
+    },
+    web: {
+      login: {
+        enabled: true
+      }
+    }
+  });
+
+  app.get('/private', stormpath.groupsRequired(groupsToAssert, assertAll), function (req, res) {
+    res.send('Ok!');
+  });
+
+  return app;
+}
+
 describe('groupsRequired', function () {
+  var stormpathClient;
   var stormpathAccount;
+  var stormpathApplication;
+
   var stormpathAccountData = {
     givenName: uuid.v4(),
     surname: uuid.v4(),
     email: uuid.v4() + '@test.com',
     password: uuid.v4() + uuid.v4().toUpperCase() + '!'
   };
-  var stormpathApplication;
-  var stormpathClient;
 
-  before(function (done) {
+  beforeEach(function (done) {
     stormpathClient = helpers.createClient();
     helpers.createApplication(stormpathClient, function (err, application) {
       if (err) {
@@ -37,123 +57,139 @@ describe('groupsRequired', function () {
     });
   });
 
-  after(function (done) {
+  afterEach(function (done) {
     helpers.destroyApplication(stormpathApplication, done);
   });
 
-  it('should redirect unauthenticated users to the login url', function (done) {
-    var app = helpers.createStormpathExpressApp({
-      application: {
-        href: stormpathApplication.href
-      },
-      web: {
-        login: {
-          enabled: true
-        }
-      }
+  describe('when providing a application/json Accept header', function () {
+    it('should give a 401 JSON response to unauthenticated users', function (done) {
+      var app = createExpressTestApp(stormpathApplication.href, ['admins']);
+
+      app.on('stormpath.ready', function () {
+        request(app)
+          .get('/private')
+          .set('Accept', 'application/json')
+          .expect(401)
+          .expect('Content-Type', /json/)
+          .expect(JSON.stringify({
+            status: 401,
+            message: 'You are not authenticated. Please log in to access this resource.'
+          }))
+          .end(done);
+      });
     });
 
-    app.get('/private', stormpath.groupsRequired(['admins']), function (req, res) {
-      res.send('Ok!');
-    });
+    it('should give a 403 forbidden for JSON response to authenticated users who do not meet group criteria', function (done) {
+      var app = createExpressTestApp(stormpathApplication.href, ['admins']);
 
-    app.on('stormpath.ready', function () {
-      request(app)
-        .get('/private')
-        .expect(302)
-        .expect('Location', app.get('stormpathConfig').web.login.uri + '?next=' + encodeURIComponent('/private'))
-        .end(done);
-    });
-  });
-
-  it('should show an unauthorized page to authenticated users who do not meet group criteria', function (done) {
-    var app = helpers.createStormpathExpressApp({
-      application: {
-        href: stormpathApplication.href
-      },
-      web: {
-        login: {
-          enabled: true
-        }
-      }
-    });
-
-    app.get('/private', stormpath.groupsRequired(['admins']), function (req, res) {
-      res.send('Ok!');
-    });
-
-    app.on('stormpath.ready', function () {
-      var agent = request.agent(app);
-
-      agent
-        .post('/login')
-        .send({
-          login: stormpathAccountData.email,
-          password: stormpathAccountData.password
-        })
-        .expect(302)
-        .expect('Location', '/')
-        .end(function () {
-          agent
-            .get('/private')
-            .expect(200)
-            .end(done);
-        });
-    });
-  });
-
-  it('should show allow users through who pass group assertion checks', function (done) {
-    var app = helpers.createStormpathExpressApp({
-      application: {
-        href: stormpathApplication.href
-      },
-      web: {
-        login: {
-          enabled: true
-        }
-      }
-    });
-
-    app.get('/private', stormpath.groupsRequired(['admins', 'developers'], false), function (req, res) {
-      res.send('Ok!');
-    });
-
-    app.on('stormpath.ready', function () {
-      var developersGroup = null;
-      var agent = request.agent(app);
-
-      async.series([
-        function (callback) {
-          app.get('stormpathApplication').createGroup({ name: 'admins' }, function (err) {
-            if (err) {
-              return callback(err);
-            }
-
-            callback();
-          });
-        },
-        function (callback) {
-          app.get('stormpathApplication').createGroup({ name: 'developers' }, function (err, group) {
-            if (err) {
-              return callback(err);
-            }
-
-            developersGroup = group;
-            callback();
-          });
-        },
-        function (callback) {
-          stormpathAccount.addToGroup(developersGroup, function (err) {
-            callback(err);
-          });
-        }
-      ], function (err) {
-        if (err) {
-          return done(err);
-        }
+      app.on('stormpath.ready', function () {
+        var agent = request.agent(app);
 
         agent
           .post('/login')
+          .send({
+            login: stormpathAccountData.email,
+            password: stormpathAccountData.password
+          })
+          .set('Accept', 'application/json')
+          .expect(401)
+          .expect('Content-Type', /json/)
+          .end(function () {
+            agent
+              .get('/private')
+              .set('Accept', 'application/json')
+              .expect(403)
+              .expect('Content-Type', /json/)
+              .expect(JSON.stringify({
+                status: 403,
+                message: 'You do not have sufficient permissions to access this resource.'
+              }))
+              .end(done);
+          });
+      });
+    });
+
+    it('should forward authorized calls to the next middleware', function (done) {
+      var app = createExpressTestApp(stormpathApplication.href, ['admins', 'developers'], false);
+
+      app.on('stormpath.ready', function () {
+        var developersGroup = null;
+        var agent = request.agent(app);
+
+        async.series([
+          function (callback) {
+            app.get('stormpathApplication').createGroup({ name: 'admins' }, function (err) {
+              if (err) {
+                return callback(err);
+              }
+
+              callback();
+            });
+          },
+          function (callback) {
+            app.get('stormpathApplication').createGroup({ name: 'developers' }, function (err, group) {
+              if (err) {
+                return callback(err);
+              }
+
+              developersGroup = group;
+              callback();
+            });
+          },
+          function (callback) {
+            stormpathAccount.addToGroup(developersGroup, function (err) {
+              callback(err);
+            });
+          }
+        ], function (err) {
+          if (err) {
+            return done(err);
+          }
+
+          agent
+            .post('/login')
+            .send({
+              login: stormpathAccountData.email,
+              password: stormpathAccountData.password
+            })
+            .expect(302)
+            .expect('Location', '/')
+            .end(function () {
+              agent
+                .get('/private')
+                .set('Accept', 'application/json')
+                .expect(200)
+                .expect('Ok!')
+                .end(done);
+            });
+        });
+      });
+    });
+  });
+
+  describe('when providing a text/html Accept header', function () {
+    it('should redirect unauthenticated users to the login url', function (done) {
+      var app = createExpressTestApp(stormpathApplication.href, ['admins']);
+
+      app.on('stormpath.ready', function () {
+        request(app)
+          .get('/private')
+          .set('Accept', 'text/html')
+          .expect(302)
+          .expect('Location', app.get('stormpathConfig').web.login.uri + '?next=' + encodeURIComponent('/private'))
+          .end(done);
+      });
+    });
+
+    it('should show an unauthorized page to authenticated users who do not meet group criteria', function (done) {
+      var app = createExpressTestApp(stormpathApplication.href, ['admins']);
+
+      app.on('stormpath.ready', function () {
+        var agent = request.agent(app);
+
+        agent
+          .post('/login')
+          .set('Accept', 'text/html')
           .send({
             login: stormpathAccountData.email,
             password: stormpathAccountData.password
@@ -163,10 +199,80 @@ describe('groupsRequired', function () {
           .end(function () {
             agent
               .get('/private')
-              .expect(200)
-              .expect('Ok!')
+              .expect(403)
               .end(done);
           });
+      });
+    });
+
+    it('should show allow users through who pass group assertion checks', function (done) {
+      var app = createExpressTestApp(stormpathApplication.href, ['admins', 'developers'], false);
+
+      app.on('stormpath.ready', function () {
+        var developersGroup = null;
+        var agent = request.agent(app);
+
+        async.series([
+          function (callback) {
+            app.get('stormpathApplication').createGroup({ name: 'admins' }, function (err) {
+              if (err) {
+                return callback(err);
+              }
+
+              callback();
+            });
+          },
+          function (callback) {
+            app.get('stormpathApplication').createGroup({ name: 'developers' }, function (err, group) {
+              if (err) {
+                return callback(err);
+              }
+
+              developersGroup = group;
+              callback();
+            });
+          },
+          function (callback) {
+            stormpathAccount.addToGroup(developersGroup, function (err) {
+              callback(err);
+            });
+          }
+        ], function (err) {
+          if (err) {
+            return done(err);
+          }
+
+          agent
+            .post('/login')
+            .set('Accept', 'text/html')
+            .send({
+              login: stormpathAccountData.email,
+              password: stormpathAccountData.password
+            })
+            .expect(302)
+            .expect('Location', '/')
+            .end(function () {
+              agent
+                .get('/private')
+                .expect(200)
+                .expect('Ok!')
+                .end(done);
+            });
+        });
+      });
+    });
+  });
+
+  describe('when not providing an Accept header', function () {
+    it('should redirect unauthenticated users to the login url', function (done) {
+      var app = createExpressTestApp(stormpathApplication.href, ['admins']);
+
+      app.on('stormpath.ready', function () {
+        request(app)
+          .get('/private')
+          .expect(302)
+          .expect('Location', app.get('stormpathConfig').web.login.uri + '?next=' + encodeURIComponent('/private'))
+          .end(done);
       });
     });
   });


### PR DESCRIPTION
Fixes the `groupsRequired` middleware so that it responds correctly to the Accept header.

##### How to verify

1. Create a new application using [this gist](https://gist.githubusercontent.com/typerandom/7a85bdaf7792e067c230faea6a56d301/raw/35944ec0d05cd26221f0d475d36fcd83e195fb69/stormpath-express-groups-required-example.js).
2. Without being authenticated, send a `GET` request to `/admin` with a `Accept: text/html` header. This should respond with a location header, redirecting you to the login.
3. Without being authenticated, send a `GET` request to `/admin` with a `Accept: application/json` header. This should respond with a JSON response body and a `401 Unauthorized` status code.
4. Being authenticated, send a `GET` request to `/admin` with a `Accept: text/html` header. This should respond with a location header, redirecting you to the login.
5. Being authenticated, send a `GET` request to `/admin` with a `Accept: application/json` header. This should respond with a JSON response body and a `403 Forbidden` status code.
6. Add the user you are authenticated with in a group called `admin`.
4. Being authenticated in the `admin` group, send a `GET` request to `/admin` with a `Accept: text/html` header. This should respond with a `200 OK` and the JSON response `{message: 'You are an administrator!'}`.
5. Being authenticated in the `admin` group, send a `GET` request to `/admin` with a `Accept: application/json` header. This should respond with a `200 OK` and the JSON response `{message: 'You are an administrator!'}`.

Fixes #408.