### PR TITLE
Fix issue with res.render() in render util not being called with original view path

### DIFF
--- a/lib/helpers/render.js
+++ b/lib/helpers/render.js
@@ -57,7 +57,7 @@ module.exports = function (req, res, view, options) {
     res.send(renderJade(view, options));
   } else if (extension) {
     // Delegate to the view engine.
-    res.render(filename, options);
+    res.render(view, options);
   } else {
     throw new Error('Unexpected view option: "' + view + '".  Please see documentation for express-stormpath');
   }


### PR DESCRIPTION
Fixes so that the render method calls res.render() with the original view path.

#### How to verify

(will be added soon)

Fixes #404