### PR TITLE
Fix login/registration handlers for oauth provider login

### DIFF
--- a/lib/helpers/login-with-oauth-provider.js
+++ b/lib/helpers/login-with-oauth-provider.js
@@ -51,7 +51,7 @@ module.exports = function loginWithOAuthProvider(options, req, res) {
       });
     }
 
-    function continueWithHandlers(preHandler, postHandler) {
+    function continueWithHandlers(preHandler, postHandler, onCompleted) {
       preHandler(options, req, res, function (err) {
         if (err) {
           return oauth.errorResponder(req, res, err);
@@ -63,20 +63,22 @@ module.exports = function loginWithOAuthProvider(options, req, res) {
               return oauth.errorResponder(req, res, err);
             }
 
-            continueWithTokenExchange();
+            onCompleted();
           });
         }
 
-        continueWithTokenExchange();
+        onCompleted();
       });
     }
 
     if (preRegistrationHandler && providerAccountResult.created) {
-      return continueWithHandlers(preRegistrationHandler, postRegistrationHandler);
+      return continueWithHandlers(preRegistrationHandler, postRegistrationHandler, function () {
+        continueWithHandlers(preLoginHandler, postLoginHandler, continueWithTokenExchange);
+      });
     }
 
-    if (preLoginHandler && !providerAccountResult.created) {
-      return continueWithHandlers(preLoginHandler, postLoginHandler);
+    if (preLoginHandler) {
+      return continueWithHandlers(preLoginHandler, postLoginHandler, continueWithTokenExchange);
     }
 
     continueWithTokenExchange();

--- a/lib/helpers/login-with-oauth-provider.js
+++ b/lib/helpers/login-with-oauth-provider.js
@@ -21,8 +21,11 @@ module.exports = function loginWithOAuthProvider(options, req, res) {
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
   var application = req.app.get('stormpathApplication');
+  var preLoginHandler = config.preLoginHandler;
+  var postLoginHandler = config.postLoginHandler;
+  var preRegistrationHandler = config.preRegistrationHandler;
+  var postRegistrationHandler = config.postRegistrationHandler;
 
-  // TODO: Add preLoginHandler support here
   application.getAccount(options, function (err, providerAccountResult) {
     if (err) {
       return oauth.errorResponder(req, res, err);
@@ -30,20 +33,52 @@ module.exports = function loginWithOAuthProvider(options, req, res) {
 
     var account = providerAccountResult.account;
 
-    exchangeStormpathToken(req, account, function (err, authResult) {
-      if (err) {
-        return writeJsonError(res, err);
-      }
-
-      expandAccount(account, config.expand, logger, function (err, expandedAccount) {
+    function continueWithTokenExchange() {
+      exchangeStormpathToken(req, account, function (err, authResult) {
         if (err) {
-          return writeJsonError(res, err);
+          return oauth.errorResponder(req, res, err);
         }
 
-        createSession(authResult, expandedAccount, req, res);
+        expandAccount(account, config.expand, logger, function (err, expandedAccount) {
+          if (err) {
+            return writeJsonError(res, err);
+          }
 
-        loginResponder(req, res);
+          createSession(authResult, expandedAccount, req, res);
+
+          loginResponder(req, res);
+        });
       });
-    });
+    }
+
+    function continueWithHandlers(preHandler, postHandler) {
+      preHandler(options, req, res, function (err) {
+        if (err) {
+          return oauth.errorResponder(req, res, err);
+        }
+
+        if (postHandler) {
+          return postHandler(account, req, res, function (err) {
+            if (err) {
+              return oauth.errorResponder(req, res, err);
+            }
+
+            continueWithTokenExchange();
+          });
+        }
+
+        continueWithTokenExchange();
+      });
+    }
+
+    if (preRegistrationHandler && providerAccountResult.created) {
+      return continueWithHandlers(preRegistrationHandler, postRegistrationHandler);
+    }
+
+    if (preLoginHandler && !providerAccountResult.created) {
+      return continueWithHandlers(preLoginHandler, postLoginHandler);
+    }
+
+    continueWithTokenExchange();
   });
 };


### PR DESCRIPTION
Fixes so that login/registration pre/post handlers are triggered when authenticating with an OAuth provider.

#### How to verify

Create a sample application that defines pre and post login, registration handlers.

When using the access token flow for a social provider, and authenticating for the first time (and account will be created in stormpath), the following handlers should be run:

* preRegistrationHandler
* postRegistrationHandler
* preLoginHandler
* postLoginHandler

Then when authenticating for a second time (the account already exists in stormpath), the following handlers should run:

* preLoginHandler
* postLoginHandler

Fixes #451 
Fixes #452