### PR TITLE
Surface token exchange errors via info() logger

### DIFF
--- a/lib/helpers/exchange-stormpath-token.js
+++ b/lib/helpers/exchange-stormpath-token.js
@@ -36,5 +36,11 @@ module.exports = function exchangeStormpathToken(req, account, callback) {
     stormpath_token: token.compact()
   };
 
-  authenticator.authenticate(options, callback);
+  authenticator.authenticate(options, function errorLogger() {
+    if (arguments[0] !== null) {
+      var logger = req.app.get('stormpathLogger');
+      logger.info('Token exchange failed', arguments[0]);
+    }
+    callback.apply(null, arguments);
+  });
 };


### PR DESCRIPTION
This will make it easier to debug issues with social login flows, where things can go wrong at this step, specifically if the clock of the local sever is not in sync with ntp, and we get a token expired error because of it.