### PR TITLE
Implement better dynamic host resolution

### DIFF
--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -39,7 +39,7 @@ module.exports = function (req, res) {
 
   var provider = config.web.social.facebook;
   var authUrl = 'https://graph.facebook.com/oauth/access_token';
-  var baseUrl = config.web.baseUrl || req.protocol + '://' + req.get('host');
+  var baseUrl = config.web.baseUrl || req.protocol + '://' + helpers.getHost(req);
 
   function loginWithAccessToken(accessToken) {
     if (!accessToken) {

--- a/lib/controllers/github-login.js
+++ b/lib/controllers/github-login.js
@@ -28,9 +28,15 @@ module.exports = function (req, res) {
   var loginHandler = config.postLoginHandler;
   var registrationHandler = config.postRegistrationHandler;
   var provider = config.web.social.github;
-  var baseUrl = config.web.baseUrl || req.protocol + '://' + req.get('host');
+  var baseUrl = config.web.baseUrl || req.protocol + '://' + helpers.getHost(req);
   var authUrl = 'https://github.com/login/oauth/access_token';
   var code = req.query.code;
+  var error = req.query.error;
+
+  if (error) {
+    logger.info('A user attempted to log in via GitHub OAuth but recieved the error " ' + error + '"');
+    return oauth.errorResponder(req, res, new Error(error));
+  }
 
   if (!code) {
     logger.info('A user attempted to log in via GitHub OAuth without specifying an OAuth token.');

--- a/lib/helpers/get-host.js
+++ b/lib/helpers/get-host.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Get the host header value of a request, which should from from the 'Host'
+ * header or the 'X-Forwarded-Host' header, if the appliation has been
+ * configured to trust upstream proxies via app.set('trust proxy', true);
+ *
+ * This function exists because in Express < 5, the req.host value is unreliable
+ * beacuse it strips the port, e.g. if the header is `Host: localhost:3000`,
+ * then req.host will report `localhost`, which is incorrect and will break URL
+ * building.
+ *
+ * See https://github.com/expressjs/express/issues/2179
+ *
+ * @param      {<type>}  req     The request
+ * @return     {<type>}  { description_of_the_return_value }
+ */
+module.exports = function getHost(req) {
+  var hostHeader = req.headers.host;
+  var xForwardedHostHeader = req.headers['x-forwarded-host'];
+  return req.app.get('trust proxy') ? (xForwardedHostHeader || hostHeader) : hostHeader;
+};

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -7,6 +7,7 @@ module.exports = {
   createStormpathSession: require('./create-stormpath-session'),
   createSession: require('./create-session'),
   expandAccount: require('./expand-account'),
+  getHost: require('./get-host'),
   getRequiredRegistrationFields: require('./get-required-registration-fields'),
   getUser: require('./get-user'),
   getAppModuleVersion: require('./get-app-module-version'),

--- a/lib/oauth/linkedin.js
+++ b/lib/oauth/linkedin.js
@@ -1,11 +1,9 @@
 'use strict';
 
+var getHost = require('../helpers/get-host');
 var request = require('request');
 
 module.exports = {
-  _getBaseUrl: function (req) {
-    return req.protocol + '://' + req.get('host');
-  },
 
   /**
    * Exchange a LinkedIn authentication code for a OAuth access token.
@@ -18,6 +16,7 @@ module.exports = {
    * @param {string} callback - The callback to call once a response has been resolved.
    */
   exchangeAuthCodeForAccessToken: function (req, config, callback) {
+    var baseUrl = config.web.baseUrl || req.protocol + '://' + getHost(req);
     var linkedInAuthUrl = 'https://www.linkedin.com/uas/oauth2/accessToken';
     var linkedInProvider = config.web.social.linkedin;
 
@@ -25,7 +24,7 @@ module.exports = {
       form: {
         grant_type: 'authorization_code',
         code: req.query.code,
-        redirect_uri: this._getBaseUrl(req) + linkedInProvider.uri,
+        redirect_uri: baseUrl + linkedInProvider.uri,
         client_id: linkedInProvider.clientId,
         client_secret: linkedInProvider.clientSecret
       }

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -123,7 +123,7 @@ module.exports.init = function (app, opts) {
 
     function localsMiddleware(req, res, next) {
       // Helper for getting the current URL.
-      res.locals.url = req.protocol + '://' + req.get('host');
+      res.locals.url = req.protocol + '://' + helpers.getHost(req);
 
       // Make the app object available for access in all templates.
       res.locals.app = req.app;


### PR DESCRIPTION
Due to this issue: https://github.com/expressjs/express/issues/2179

This fixes social login, when running behind a reverse proxy, where the redirect URL is dependent on proper hostname resolution.