### PR TITLE
Fix: Social login not respecting ?next

### DIFF
--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -75,7 +75,11 @@ module.exports = function (req, res) {
             return oauth.errorResponder(req, res, err);
           }
 
-          var nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+          var nextUrl = oauth.common.consumeRedirectUri(req, res);
+
+          if (!nextUrl) {
+            nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+          }
 
           if (resp.created && registrationHandler) {
             registrationHandler(req.user, req, res, function () {

--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -78,7 +78,7 @@ module.exports = function (req, res) {
           var nextUrl = oauth.common.consumeRedirectUri(req, res);
 
           if (!nextUrl) {
-            nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+            nextUrl = resp.created ? config.web.register.nextUri : config.web.login.nextUri;
           }
 
           if (resp.created && registrationHandler) {

--- a/lib/controllers/facebook-login.js
+++ b/lib/controllers/facebook-login.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var url = require('url');
-
 var helpers = require('../helpers');
 var oauth = require('../oauth');
 

--- a/lib/controllers/github-login.js
+++ b/lib/controllers/github-login.js
@@ -80,7 +80,7 @@ module.exports = function (req, res) {
           var nextUrl = oauth.common.consumeRedirectUri(req, res);
 
           if (!nextUrl) {
-            nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+            nextUrl = resp.created ? config.web.register.nextUri : config.web.login.nextUri;
           }
 
           if (resp.created && registrationHandler) {

--- a/lib/controllers/github-login.js
+++ b/lib/controllers/github-login.js
@@ -77,7 +77,11 @@ module.exports = function (req, res) {
             return oauth.errorResponder(req, res, err);
           }
 
-          var nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+          var nextUrl = oauth.common.consumeRedirectUri(req, res);
+
+          if (!nextUrl) {
+            nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+          }
 
           if (resp.created && registrationHandler) {
             registrationHandler(req.user, req, res, function () {

--- a/lib/controllers/github-login.js
+++ b/lib/controllers/github-login.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var url = require('url');
-
 var helpers = require('../helpers');
 var oauth = require('../oauth');
 

--- a/lib/controllers/google-login.js
+++ b/lib/controllers/google-login.js
@@ -67,7 +67,7 @@ module.exports = function (req, res) {
         var nextUrl = oauth.common.consumeRedirectUri(req, res);
 
         if (!nextUrl) {
-          nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+          nextUrl = resp.created ? config.web.register.nextUri : config.web.login.nextUri;
         }
 
         if (resp.created && registrationHandler) {

--- a/lib/controllers/google-login.js
+++ b/lib/controllers/google-login.js
@@ -64,7 +64,11 @@ module.exports = function (req, res) {
           return oauth.errorResponder(req, res, err);
         }
 
-        var nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+        var nextUrl = oauth.common.consumeRedirectUri(req, res);
+
+        if (!nextUrl) {
+          nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+        }
 
         if (resp.created && registrationHandler) {
           registrationHandler(req.user, req, res, function () {

--- a/lib/controllers/google-login.js
+++ b/lib/controllers/google-login.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var url = require('url');
-
 var helpers = require('../helpers');
 var oauth = require('../oauth');
 

--- a/lib/controllers/linkedin-login.js
+++ b/lib/controllers/linkedin-login.js
@@ -72,7 +72,7 @@ module.exports = function (req, res) {
         var nextUrl = oauth.common.consumeRedirectUri(req, res);
 
         if (!nextUrl) {
-          nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
+          nextUrl = resp.created ? config.web.register.nextUri : config.web.login.nextUri;
         }
 
         if (resp.created && registrationHandler) {

--- a/lib/controllers/linkedin-login.js
+++ b/lib/controllers/linkedin-login.js
@@ -70,6 +70,7 @@ module.exports = function (req, res) {
         }
 
         var nextUrl = oauth.common.consumeRedirectUri(req, res);
+
         if (!nextUrl) {
           nextUrl = url.parse(req.query.next || '').path || (resp.created ? config.web.register.nextUri : config.web.login.nextUri);
         }

--- a/lib/controllers/linkedin-login.js
+++ b/lib/controllers/linkedin-login.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var url = require('url');
-
 var helpers = require('../helpers');
 var oauth = require('../oauth');
 

--- a/lib/helpers/set-temp-cookie.js
+++ b/lib/helpers/set-temp-cookie.js
@@ -10,11 +10,16 @@
  * @param {string} name - The name of the cookie.
  * @param {string} name - The value of the cookie.
  * @param {string} maxAge - The max number of seconds the cookie is allowed to live.
+ * @param {boolean} signed - Whether or not to sign the cookie. Defaults to true.
  */
-module.exports = function (res, name, value, maxAge) {
+module.exports = function (res, name, value, maxAge, signed) {
   if (maxAge === undefined) {
     maxAge = 60 * 5;
   }
 
-  res.cookie(name, value, { maxAge: maxAge * 1000, httpOnly: true });
+  res.cookie(name, value, {
+    maxAge: maxAge * 1000,
+    httpOnly: true,
+    signed: signed === undefined ? true : signed
+  });
 };

--- a/lib/oauth/common.js
+++ b/lib/oauth/common.js
@@ -65,7 +65,7 @@ module.exports = {
    * @return {mixed} The redirect uri (string) or false if didn't exist.
    */
   consumeRedirectUri: function (req, res) {
-    var redirectTo = req.cookies.oauthRedirectUri || false;
+    var redirectTo = req.signedCookies.oauthRedirectUri || false;
 
     if (redirectTo) {
       res.clearCookie('oauthRedirectUri');

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -141,7 +141,9 @@ module.exports.init = function (app, opts) {
     }
 
     router.use(localsMiddleware);
-    router.use(cookieParser());
+
+    // Sign cookies with the API-key secret.
+    router.use(cookieParser(config.client.apiKey.secret));
 
     if (web.idSite.enabled) {
       addGetRoute(web.idSite.uri, controllers.idSiteVerify);

--- a/test/helpers/test-get-user.js
+++ b/test/helpers/test-get-user.js
@@ -84,7 +84,7 @@ describe('getUser', function () {
       ]
     }));
     app.set('stormpathConfig', config);
-    app.use(cookieParser());
+    app.use(cookieParser('mocksecret'));
 
     return function (req, res, next) {
       req.app = app;


### PR DESCRIPTION
Fixes so that login with social providers support the `?next` query string parameter.

#### How to verify

1. Checkout this branch.
2. Run `$ npm link`.
3. Use [this](https://gist.github.com/typerandom/0887f0085c77ccadd2f04859ce876385) example application.
4. Link it to the branch `$ npm link express-stormpath`.
5. Run the application.
6. Navigate to `http://localhost:3000/hello`.
7. Verify that you are redirected to `http://localhost:3000/login?next=%2Fhello`.
8. Login with either Facebook, Google, GitHub or LinkedIn.
9. Verify that you are redirected back to `http://localhost:3000/hello`.

#### Discussion

The API-key secret is used to sign the `oauthStateRedirectUri` cookie. Any objections to this?

Fixes #482