### PR TITLE
Fix OAuth login case when postRegistrationHandler is set but preLoginHandler is missing

### DIFF
--- a/lib/helpers/login-with-oauth-provider.js
+++ b/lib/helpers/login-with-oauth-provider.js
@@ -52,6 +52,13 @@ module.exports = function loginWithOAuthProvider(options, req, res) {
     }
 
     function continueWithHandlers(preHandler, postHandler, onCompleted) {
+      // If there's no preHandler, then provide a default one.
+      if (!preHandler) {
+        preHandler = function (options, req, res, callback) {
+          callback();
+        };
+      }
+
       preHandler(options, req, res, function (err) {
         if (err) {
           return oauth.errorResponder(req, res, err);


### PR DESCRIPTION
Fixes the OAuth login case where the `postRegistrationHandler` is set without `preLoginHandler`.
#### How to verify
1. Set a `postRegistrationHandler` in config.
2. Start your express test application and login in with a OAuth provider.
3. Verify that you see the error `TypeError: preHandler is not a function` in console.
4. Checkout this branch.
5. Start your express test application and login in with a OAuth provider.
6. Verify that you are able to login without any error being shown in console.

Fixes #513
