### PR TITLE
Add OAuth2 password grant preLoginHandler and postLoginHandler support

### DIFF
--- a/docs/login.rst
+++ b/docs/login.rst
@@ -143,10 +143,10 @@ takes in four parameters:
   request directly.
 - ``res``: The Express response object.  This can be used to modify the HTTP
   response directly.
-- ``next``: The callback to call after you have done your custom work.  If you
-  call this with an error then we immediately return this error to the user and
-  form processing stops.  But if you call it without an error, then our library
-  will continue to process the form and respond with the default behavior.
+- ``next``: The callback to call after you have done your custom work, this tells
+  our library to continue with the default response.  If you don't call this,
+  you're responsible for handling the response.  If you call this with an error
+  then we stop the login procedure and show the error to the user.
 
 In the example below, we'll use the ``preLoginHandler`` to validate that
 the user doesn't enter an email domain that is restricted::
@@ -191,16 +191,17 @@ takes in four parameters:
   request directly.
 - ``res``: The Express response object.  This can be used to modify the HTTP
   response directly.
-- ``next``: The callback to call when you're done doing whatever it is you want
-  to do.  If you call this, execution will continue on normally.  If you don't
-  call this, you're responsible for handling the response.
+- ``next``: The callback to call after you have done your custom work, this tells
+  our library to continue with the default response.  If you don't call this,
+  you're responsible for handling the response.  If you call this with an error
+  then we show this error to the user, but the token cookies are still created.
 
 In the example below, we'll use the ``postLoginHandler`` to redirect the
 user to a special page (*instead of the normal login flow*)::
 
     app.use(stormpath.init(app, {
       postLoginHandler: function (account, req, res, next) {
-        res.redirect(302, '/secretpage').end();
+        res.redirect(302, '/secretpage');
       }
     }));
 

--- a/lib/controllers/get-token.js
+++ b/lib/controllers/get-token.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var stormpath = require('stormpath');
+var expandAccount = require('../helpers/expand-account');
 
 /**
  * Allow a developer to exchange their API keys for an OAuth token.
@@ -31,6 +32,50 @@ module.exports = function (req, res) {
     return res.status(err.status || err.statusCode || 400).json(error);
   }
 
+  function writeSuccessResponse(authResult) {
+    res.json(authResult.accessTokenResponse);
+  }
+
+  function continueWithHandlers(authResult, preHandler, postHandler, onCompleted) {
+    var options = req.body || {};
+
+    if (!preHandler) {
+      preHandler = function (options, req, res, next) {
+        next();
+      };
+    }
+
+    preHandler(options, req, res, function (err) {
+      if (err) {
+        return writeErrorResponse(err);
+      }
+
+      if (postHandler) {
+        return authResult.getAccount(function (err, account) {
+          if (err) {
+            return writeErrorResponse(err);
+          }
+
+          expandAccount(account, config.expand, logger, function (err, expandedAccount) {
+            if (err) {
+              return writeErrorResponse(err);
+            }
+
+            return config.postLoginHandler(expandedAccount, req, res, function (err) {
+              if (err) {
+                return writeErrorResponse(err);
+              }
+
+              onCompleted();
+            });
+          });
+        });
+      }
+
+      onCompleted();
+    });
+  }
+
   if (!isPostRequest) {
     return res.status(405).end();
   }
@@ -50,7 +95,16 @@ module.exports = function (req, res) {
           return writeErrorResponse(err);
         }
 
-        res.json(authResult.accessTokenResponse);
+        if (grantType === 'password' && (config.preLoginHandler || config.postLoginHandler)) {
+          return continueWithHandlers(
+            authResult,
+            config.preLoginHandler,
+            config.postLoginHandler,
+            writeSuccessResponse.bind(null, authResult)
+          );
+        }
+
+        writeSuccessResponse(authResult);
       });
       break;
 


### PR DESCRIPTION
Add so that the OAuth2 endpoint (/oauth/token) supports the preLoginHandler and postLoginHandler when authenticating using password grant.
#### How to verify

Use the code below:

``` javascript
var express = require('express');
var stormpath = require('express-stormpath');

var app = express();

app.use(stormpath.init(app, {
  preLoginHandler: function (options, req, res, next) {
    console.log('Got login request', options);
    next();
  },
  postLoginHandler: function (account, req, res, next) {
    console.log('Logged in as ', account.href);
    next();
  }
}));

app.listen(3000, function () {
  console.log('Listening on http://localhost:3000/!');
});
```

And then call the endpoint `http://localhost:3000/oauth/token` with the form body `grant_type=password&username=(valid username)&password=(valid password)`.

Then verify that the test application works as expected when using only the `preLoginHandler`, then using only the `postLoginHandler`, then using both of them.

And then finally, using none of them.

Fixes #507
