### PR TITLE
Updating docs to use google tag manager

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -2,35 +2,5 @@
 
 {% block footer %}
   {{ super() }}
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-29159574-1', 'auto');
-    ga('send', 'pageview');
-  </script>
-  <script type="text/javascript">
-    (function(d,s,i,r) {
-        if (d.getElementById(i)){return;}
-        var n=d.createElement(s),e=d.getElementsByTagName(s)[0];
-        n.id=i;n.src='//js.hs-analytics.net/analytics/'+(Math.ceil(new Date()/r)*r)+'/475298.js';
-        e.parentNode.insertBefore(n, e);
-    })(document,"script","hs-analytics",300000);
-  </script>
-  <script type="text/javascript">
-    var _kmq = _kmq || [];
-    var _kmk = _kmk || '684b854336bd3a6523260ebd991eec06b18b929a';
-    function _kms(u){
-        setTimeout(function(){
-            var d = document, f = d.getElementsByTagName('script')[0],
-                    s = d.createElement('script');
-            s.type = 'text/javascript'; s.async = true; s.src = u;
-            f.parentNode.insertBefore(s, f);
-        }, 1);
-    }
-    _kms('//i.kissmetrics.com/i.js');
-    _kms('//doug1izaerwt3.cloudfront.net/' + _kmk + '.1.js');
-  </script>
   <script src="//cdn.optimizely.com/js/225847041.js"></script>
 {% endblock %}


### PR DESCRIPTION
We added the GTM script to the upstream sphinx theme:

https://github.com/stormpath/stormpath-sphinx-theme/pull/3

As such, removing the old scripts in the local layout override.  Optimizely does need to stay in the fodder.