### PR TITLE
Resolve error message from OAuth error

### DIFF
--- a/lib/oauth/common.js
+++ b/lib/oauth/common.js
@@ -120,7 +120,13 @@ module.exports = {
         }
 
         if (parsedBody.error) {
-          return callback(new Error(parsedBody.error));
+          var errorMessage = parsedBody.error;
+
+          if (errorMessage.message) {
+            errorMessage = errorMessage.message;
+          }
+
+          return callback(new Error(errorMessage));
         }
       }
 


### PR DESCRIPTION
When a Facebook OAuth callback errors then resolve the error message from [Facebook's error structure](https://developers.facebook.com/docs/graph-api/using-graph-api#receiving-errorcodes).
#### How to verify
1. Start an example application and navigate to `/login`.
2. Click the login to Facebook login link.
3. While being on the Facebook OAuth provider page prompting you to authorize your application to access your Facebook account. Go into the Facebook Developer dashboard and remove your whitelisted callback URI.
4. Go back to the Facebook provider page and authorize your application to access the account.
5. You should be redirected back to `/login` and with an error message stating `[object Object]`.
6. Redo steps 1-4 but without removing your whitelisted callback URI.
7. You should now see a proper error message (not `[object Object]`).

Fixes #528
