### PR TITLE
Fix host used in id site redirect callback

### DIFF
--- a/lib/controllers/id-site-redirect.js
+++ b/lib/controllers/id-site-redirect.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var getHost = require('../helpers/get-host');
+
 /**
  * This controller registers a new user using Stormpath's hosted ID Site
  * service.  This will redirect the user to the ID site which allows a user to
@@ -14,7 +16,8 @@ module.exports = function (options) {
   return function (req, res) {
     var application = req.app.get('stormpathApplication');
     var config = req.app.get('stormpathConfig');
-    var cbUri = req.protocol + '://' + req.get('host') + config.web.idSite.uri;
+    var cbUri = req.protocol + '://' + getHost(req) + config.web.idSite.uri;
+
     var url = application.createIdSiteUrl({
       callbackUri: cbUri,
       logout: options.logout,
@@ -26,6 +29,7 @@ module.exports = function (options) {
       'Location': url,
       'Pragma': 'no-cache'
     });
+
     res.end();
   };
 };


### PR DESCRIPTION
Fixes the host used in the id site redirect callback.
#### How to verify

Deploy this branch behind a proxy (e.g. on Heroku). Then with ID site enabled, try initiating a logout request and verify that you are redirected back properly.

Fixes #534
