### PR TITLE
Fix data not being expanded on register if email verification is on

### DIFF
--- a/lib/controllers/register.js
+++ b/lib/controllers/register.js
@@ -253,10 +253,14 @@ module.exports = function (req, res, next) {
                 return writeFormError(err);
               }
 
-              //console.log('Register account status!', account.status);
-
               if (account.status === 'UNVERIFIED') {
-                return handleResponse(account, defaultUnverifiedHtmlResponse);
+                return helpers.expandAccount(account, config.expand, logger, function (err, expandedAccount) {
+                  if (err) {
+                    return writeFormError(err);
+                  }
+
+                  return handleResponse(expandedAccount, defaultUnverifiedHtmlResponse);
+                });
               }
 
               if (config.web.register.autoLogin) {


### PR DESCRIPTION
Fixes an error where the account was not being expanded when calling the `postRegistrationHandler`, but only if email verification was turned on.

For reproduction steps see #549 

Fixes #549