### PR TITLE
Fix/default response content type

### DIFF
--- a/lib/helpers/handle-accept-request.js
+++ b/lib/helpers/handle-accept-request.js
@@ -26,11 +26,14 @@ function handleAcceptRequest(req, res, handlers, fallbackHandler) {
   // Accepted is an ordered list of preferred types, as specified by the request.
   var accepted = req.accepts();
   var produces = config.web.produces;
+  var defaultContentType = produces && produces.length >= 1
+    ? produces[0]
+    : 'text/html';
 
-  // Our default response is HTML, if the client does not specify something more
-  // specific.  As such, map the wildcard type to html.
+  // Our default response is the first entry in the `produces` array, if the
+  // request does not specify otherwise via the `Accepts` header.
   accepted = accepted.map(function (contentType) {
-    return contentType === '*/*' ? 'text/html' : contentType;
+    return contentType === '*/*' ? defaultContentType : contentType;
   });
 
   // Of the accepted types, find the ones that are allowed by the configuration.

--- a/test/controllers/test-email-verification.js
+++ b/test/controllers/test-email-verification.js
@@ -54,7 +54,8 @@ describe('email verification', function () {
           web: {
             register: {
               enabled: true
-            }
+            },
+            produces: ['text/html', 'application/json']
           }
         });
         expressApp.on('stormpath.ready', done);
@@ -113,8 +114,8 @@ describe('email verification', function () {
           var config = expressApp.get('stormpathConfig');
           request(expressApp)
             .post(config.web.verifyEmail.uri)
-            .send({ login: uuid() })
             .set('Accept', 'application/json')
+            .send({ login: uuid() })
             .expect(200, '', done);
         });
       });
@@ -206,7 +207,8 @@ describe('email verification', function () {
       web:{
         verifyEmail:{
           uri: '/' + uuid()
-        }
+        },
+        produces: ['text/html']
       }
     });
 

--- a/test/controllers/test-forgot-password.js
+++ b/test/controllers/test-forgot-password.js
@@ -70,7 +70,8 @@ describe('forgotPassword', function () {
       web: {
         forgotPassword: {
           enabled: true
-        }
+        },
+        produces: ['text/html', 'application/json']
       }
     });
 
@@ -101,7 +102,8 @@ describe('forgotPassword', function () {
       web: {
         forgotPassword: {
           enabled: true
-        }
+        },
+        produces: ['text/html', 'application/json']
       }
     });
 
@@ -130,7 +132,8 @@ describe('forgotPassword', function () {
       web: {
         forgotPassword: {
           enabled: true
-        }
+        },
+        produces: ['text/html', 'application/json']
       }
     });
 
@@ -153,7 +156,8 @@ describe('forgotPassword', function () {
       web: {
         forgotPassword: {
           enabled: true
-        }
+        },
+        produces: ['text/html', 'application/json']
       }
     });
 
@@ -177,7 +181,8 @@ describe('forgotPassword', function () {
         web: {
           forgotPassword: {
             enabled: true
-          }
+          },
+          produces: ['text/html', 'application/json']
         }
       });
 
@@ -204,7 +209,8 @@ describe('forgotPassword', function () {
         web: {
           forgotPassword: {
             enabled: true
-          }
+          },
+          produces: ['text/html', 'application/json']
         }
       });
       spaRootFixture.before(done);

--- a/test/controllers/test-id-site.js
+++ b/test/controllers/test-id-site.js
@@ -149,7 +149,8 @@ describe('id site', function () {
               },
               idSite: {
                 enabled: true
-              }
+              },
+              produces: ['text/html', 'application/json']
             }
           });
 

--- a/test/controllers/test-login.js
+++ b/test/controllers/test-login.js
@@ -33,14 +33,18 @@ describe('login', function () {
 
       stormpathApplication = app;
       defaultExpressApp = helpers.createStormpathExpressApp({
-        application: stormpathApplication
+        application: stormpathApplication,
+        web: {
+          produces: ['text/html', 'application/json']
+        }
       });
       alternateUrlExpressApp = helpers.createStormpathExpressApp({
         application: stormpathApplication,
         web: {
           login: {
             uri: '/newlogin'
-          }
+          },
+          produces: ['text/html', 'application/json']
         }
       });
       app.createAccount(accountData, done);
@@ -240,7 +244,8 @@ describe('login', function () {
         web: {
           login: {
             enabled: true
-          }
+          },
+          produces: ['text/html', 'application/json']
         }
       });
       spaRootFixture.before(done);

--- a/test/controllers/test-logout.js
+++ b/test/controllers/test-logout.js
@@ -35,7 +35,8 @@ describe('logout', function () {
           },
           accessTokenCookie: {
             domain: 'example.com'
-          }
+          },
+          produces: ['text/html', 'application/json']
         },
         postLogoutHandler: postLogoutHandlerSpy
       });

--- a/test/controllers/test-register.js
+++ b/test/controllers/test-register.js
@@ -34,7 +34,8 @@ function DefaultRegistrationFixture(stormpathApplication) {
     web: {
       register: {
         enabled: true
-      }
+      },
+      produces: ['text/html', 'application/json']
     }
   });
   return this;
@@ -128,7 +129,8 @@ function NamesOptionalRegistrationFixture(stormpathApplication) {
             }
           }
         }
-      }
+      },
+      produces: ['text/html', 'application/json']
     }
   });
   return this;
@@ -191,7 +193,8 @@ function NamesDisabledRegistrationFixture(stormpathApplication) {
             }
           }
         }
-      }
+      },
+      produces: ['text/html', 'application/json']
     }
   });
   return this;
@@ -247,7 +250,8 @@ function CustomFieldRegistrationFixture(stormpathApplication) {
           },
           fieldOrder: ['givenName', 'surname', 'color', 'music', 'email', 'password']
         }
-      }
+      },
+      produces: ['text/html', 'application/json']
     }
   });
   return this;
@@ -405,7 +409,8 @@ describe('register', function () {
           register: {
             enabled: true,
             uri: '/customRegistrationUri'
-          }
+          },
+          produces: ['text/html', 'application/json']
         }
       });
       app.on('stormpath.ready', done);
@@ -687,7 +692,8 @@ describe('register', function () {
         web: {
           register: {
             enabled: true
-          }
+          },
+          produces: ['text/html', 'application/json']
         }
       });
       spaRootFixture.before(done);
@@ -956,7 +962,8 @@ describe('register', function () {
               autoLogin: true,
               enabled: true,
               nextUri: '/woot'
-            }
+            },
+            produces: ['text/html', 'application/json']
           }
         });
         app.on('stormpath.ready', done);

--- a/test/controllers/test-reset-password.js
+++ b/test/controllers/test-reset-password.js
@@ -75,7 +75,10 @@ describe('resetPassword', function () {
           passwordResetToken = tokenResource.href.match(/\/([^\/]+)$/)[1];
 
           defaultExpressApp = helpers.createStormpathExpressApp({
-            application: stormpathApplication
+            application: stormpathApplication,
+            web: {
+              produces: ['text/html', 'application/json']
+            }
           });
 
           defaultExpressApp.on('stormpath.ready', done);
@@ -320,7 +323,8 @@ describe('resetPassword', function () {
         web: {
           changePassword: {
             enabled: true
-          }
+          },
+          produces: ['text/html', 'application/json']
         }
       });
       spaRootFixture.before(done);

--- a/test/fixtures/spa-root-fixture.js
+++ b/test/fixtures/spa-root-fixture.js
@@ -21,7 +21,9 @@ function SpaRootFixture(stormpathConfig) {
   this.filename = '/tmp/' + uuid.v4();
 
   if (!stormpathConfig.web) {
-    stormpathConfig.web = {};
+    stormpathConfig.web = {
+      produces: ['text/html', 'application/json']
+    };
   }
 
   stormpathConfig.web.spa = {

--- a/test/handlers/test-post-registration-handler.js
+++ b/test/handlers/test-post-registration-handler.js
@@ -26,7 +26,8 @@ function preparePostRegistrationExpansionTestFixture(stormpathApplication, cb) {
             }
           }
         }
-      }
+      },
+      produces: ['text/html', 'application/json']
     },
     postRegistrationHandler: function (account, req, res) {
       // Simply return the user object, so that we can
@@ -54,6 +55,9 @@ function preparePostRegistrationPassThroughTestFixture(stormpathApplication, cb)
 
   fixture.expressApp = helpers.createStormpathExpressApp({
     application: stormpathApplication,
+    web: {
+      produces: ['text/html', 'application/json']
+    },
     postRegistrationHandler: function (account, req, res, next) {
       fixture.sideEffect = fixture.sideEffectData;
       next();
@@ -78,7 +82,8 @@ function preparePostRegistrationAutoLoginTestFixture(stormpathApplication, cb) {
       register: {
         enabled: true,
         autoLogin: true
-      }
+      },
+      produces: ['text/html', 'application/json']
     },
     postRegistrationHandler: function (account, req, res, next) {
       fixture.sideEffect = fixture.sideEffectData;

--- a/test/helpers/test-handle-accept-request.js
+++ b/test/helpers/test-handle-accept-request.js
@@ -1,0 +1,108 @@
+'use strict';
+
+var assert = require('assert');
+var sinon = require('sinon');
+
+var handleAcceptRequest = require('../../lib/helpers').handleAcceptRequest;
+
+var defaultsAccepts = ['*/*'];
+var mockReq = {
+  app: {
+    get: function get(name) {
+      return mockReq.app['_' + name];
+    },
+    _stormpathConfig: {
+      web: {
+        produces: ['application/json', 'text/html'],
+        spa: {
+          enabled: false
+        }
+      }
+    }
+  },
+  accepts: function accepts() {
+    return mockReq._accepts;
+  },
+  _accepts: defaultsAccepts
+};
+
+describe('handleAcceptRequest helper', function () {
+  describe('default response content type', function () {
+    var sandbox;
+    var jsonSpy;
+    var handlers;
+    var defaultHandler;
+
+    before(function () {
+      sandbox = sinon.sandbox.create();
+      jsonSpy = sandbox.spy();
+      handlers = {
+        'application/json': jsonSpy
+      };
+      defaultHandler = sandbox.spy();
+    });
+
+    after(function () {
+      sandbox.restore();
+    });
+
+    it('should default to the first element of `config.web.produces`', function () {
+      handleAcceptRequest(mockReq, null, handlers, defaultHandler);
+      assert(jsonSpy.calledOnce);
+      assert.equal(defaultHandler.callCount, 0);
+    });
+  });
+
+  describe('content type set via Accept', function () {
+    var oldAccepts;
+    var sandbox;
+    var htmlSpy;
+    var handlers;
+    var defaultHandler;
+
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create();
+      oldAccepts = mockReq._accepts;
+      mockReq._accepts = ['text/html'];
+      htmlSpy = sandbox.spy();
+      defaultHandler = sandbox.spy();
+      handlers = {
+        'text/html': htmlSpy
+      };
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+      mockReq._accepts = oldAccepts;
+    });
+
+    describe('when provided in produces', function () {
+      it('should call the correct handler', function () {
+        handleAcceptRequest(mockReq, null, handlers, defaultHandler);
+
+        assert(htmlSpy.calledOnce);
+        assert.equal(defaultHandler.callCount, 0);
+      });
+    });
+
+    describe('when not provided in produces', function () {
+      var oldProduces;
+
+      before(function () {
+        oldProduces = mockReq.app._stormpathConfig.web.produces.slice(0);
+        mockReq.app._stormpathConfig.web.produces = ['application/json'];
+      });
+
+      after(function () {
+        mockReq.app._stormpathConfig.web.produces = oldProduces.slice(0);
+      });
+
+      it('should call the default handler', function () {
+        handleAcceptRequest(mockReq, null, handlers, defaultHandler);
+
+        assert.equal(htmlSpy.callCount, 0);
+        assert(defaultHandler.calledOnce);
+      });
+    });
+  });
+});

--- a/test/middlewares/test-api-authentication-required.js
+++ b/test/middlewares/test-api-authentication-required.js
@@ -98,7 +98,8 @@ describe('apiAuthenticationRequired', function () {
                 password: {
                   validationStrategy: 'stormpath'
                 }
-              }
+              },
+              produces: ['text/html', 'application/json']
             }
           });
 

--- a/test/middlewares/test-get-user.js
+++ b/test/middlewares/test-get-user.js
@@ -69,7 +69,8 @@ describe('getUser', function () {
       web: {
         login: {
           enabled: true
-        }
+        },
+        produces: ['text/html', 'application/json']
       }
     });
 
@@ -463,7 +464,8 @@ describe('getUser', function () {
           password: {
             validationStrategy: 'local'
           }
-        }
+        },
+        produces: ['text/html', 'application/json']
       }
     });
 

--- a/test/middlewares/test-groups-required.js
+++ b/test/middlewares/test-groups-required.js
@@ -15,7 +15,8 @@ function createExpressTestApp(applicationHref, groupsToAssert, assertAll) {
     web: {
       login: {
         enabled: true
-      }
+      },
+      produces: ['text/html', 'application/json']
     }
   });
 


### PR DESCRIPTION
Update the controller responses (via `handleAcceptRequests`) to use `config.web.produces[0]` as the default, instead of `text/html`, if this array is defined (if not, it will explode in a later step, anyway). Adds tests to check for this behaviour, and some of the other behaviour of that helper, while I was at it.

While the commits thus far do not deal with this, it might be prudent to exchange the `next` default handlers (which result in a `404`) with something like `400 Bad Request` default handlers, which is something like what @rdegges mentioned in #487 . A not found is not really semantically correct. @robertjd, thoughts regarding this?

Another important thing to note is that this is a **breaking** change - a good number of our tests failed because they expected it to default to `text/html`. This can be solved by either defining a `['text/html', 'application/json']` value to the `config.web.produces` array, or by explicitly setting the `Accept` header. So far, it was exactly the reverse (explicit setting to `application/json` was required).

Fixes #487 