### PR TITLE
Add support for auto-expansion of application custom data

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -221,6 +221,10 @@ web:
       providerData: false
       tenant: false
 
+  application:
+    expand:
+      customData: true
+
   # If the developer wants our integration to serve their Single Page
   # Application (SPA) in response to HTML requests for our default routes,
   # such as /login, then they will need to enable this feature and tell us

--- a/lib/helpers/get-application.js
+++ b/lib/helpers/get-application.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * @function
+ * @private
+ *
+ * @description
+ * Loads the application from a href, optionally expanding fields passed via the
+ * `expand` parameter.
+ *
+ * @param {String} appHref
+ * The HREF of the application to load.
+ * @param {Object} client
+ * The Stormpath client
+ * @param {Object} expand
+ * Definition of which objects to expand as an object of string-boolean pairs.
+ * @param {Function} callback
+ * The function to call when done. Called with {err, Application}
+ */
+module.exports = function getApplication(appHref, client, expand, callback) {
+  var appOptions = {};
+  var expandOn = [];
+
+  Object.keys(expand).forEach(function (field) {
+    if (expand[field]) {
+      expandOn.push(field);
+    }
+  });
+
+  if (expandOn) {
+    appOptions.expand = expandOn.join(',');
+  }
+
+  return client.getApplication(appHref, appOptions, callback);
+};

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -24,5 +24,6 @@ module.exports = {
   xsrfValidator: require('./xsrf-validator'),
   revokeToken: require('./revoke-token'),
   getFormViewModel: require('./get-form-view-model').default,
-  strippedAccountResponse: require('./stripped-account-response')
+  strippedAccountResponse: require('./stripped-account-response'),
+  getApplication: require('./get-application')
 };

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -211,7 +211,7 @@ module.exports.init = function (app, opts) {
       router.all(web.oauth2.uri, bodyParser.form(), stormpathMiddleware, controllers.getToken);
     }
 
-    client.getApplication(config.application.href, function (err, application) {
+    helpers.getApplication(config.application.href, client, web.application.expand, function (err, application) {
       if (err) {
         throw new Error('Cannot fetch application ' + config.application.href);
       }


### PR DESCRIPTION
Adds a configuration option to `config.web` to expand the `stormpathApplication` `customData` field as:

```yaml
web:
  application:
    expand:
      customData: true # defaults to false to keep backwards compat
```

If specified, the expansion will automatically happen when attaching the `stormpathApplication` property to `req.app`. *Do note*, however, that the setting of `stormpathApplication` happens only once, on application load, so any updates will still need to be saved manually.

Fixes #440 