### PR TITLE
Update stormpath config dependency

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,15 @@ Change Log
 
 All library changes, in descending order.
 
+Version 3.1.9
+-------------
+
+**Released January 20, 2017.**
+
+- The following production dependencies have been updated:
+
+  - ``stormpath-config@0.0.26`` -> ``stormpath-config@0.0.27``
+
 Version 3.1.8
 -------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-stormpath",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "description": "Build simple, secure web applications with Stormpath and Express!",
   "keywords": [
     "express",
@@ -37,7 +37,7 @@
     "qs": "^6.0.2",
     "request": "^2.63.0",
     "stormpath": "0.19.x",
-    "stormpath-config": "0.0.26",
+    "stormpath-config": "0.0.27",
     "utils-merge": "^1.0.0",
     "uuid": "^2.0.1",
     "winston": "^2.1.1"


### PR DESCRIPTION
- The dependency stormpath-config handles the configuration
  helpers that are used by the SDK.
- This update is necessary as there is an update within the
  EnrichIntegrationFromRemoteConfigStrategy file which
  sets the client on the outerScope object.  Without this
  the calls to getGroups wil yield undefined.  This was
  resolved with this commit:
  https://github.com/stormpath/stormpath-node-config/commit/49461660d2614cbf130cb788f458fd5e0cd1c996

closes #579