### PR TITLE
Update stormpath config dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "qs": "^6.0.2",
     "request": "^2.63.0",
     "stormpath": "0.19.x",
-    "stormpath-config": "0.0.26",
+    "stormpath-config": "0.0.27",
     "utils-merge": "^1.0.0",
     "uuid": "^2.0.1",
     "winston": "^2.1.1"


### PR DESCRIPTION
- The dependency stormpath-config handles the configuration
  helpers that are used by the SDK.
- This update is necessary as there is an update within the
  EnrichIntegrationFromRemoteConfigStrategy file which
  sets the client on the outerScope object.  Without this
  the calls to getGroups wil yield undefined.  This was
  resolved with this commit:
  https://github.com/stormpath/stormpath-node-config/commit/49461660d2614cbf130cb788f458fd5e0cd1c996

closes #579 #580