### PR TITLE
Use new access token authenticator (Client API Support)

### DIFF
--- a/lib/middleware/authentication-required.js
+++ b/lib/middleware/authentication-required.js
@@ -18,6 +18,7 @@ var deleteCookies = require('./delete-cookies');
  *   processing the request if the user is authenticated.
  */
 module.exports = function (req, res, next) {
+  var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
 
   if (req.user) {
@@ -28,9 +29,11 @@ module.exports = function (req, res, next) {
   deleteCookies(req, res);
 
   if (req.accepts(['html', 'json']) === 'html') {
-    var url = req.app.get('stormpathConfig').web.login.uri + '?next=' + encodeURIComponent(req.originalUrl);
+    var url = config.web.login.uri + '?next=' + encodeURIComponent(req.originalUrl);
     return res.redirect(302, url);
   }
 
-  helpers.writeJsonError(res, { status: 401, message: 'Invalid API credentials.' });
+  var message = req.authenticationError && req.authenticationError.userMessage || 'Unauthorized';
+
+  helpers.writeJsonError(res, { status: 401, message: message });
 };

--- a/lib/middleware/get-user.js
+++ b/lib/middleware/get-user.js
@@ -2,7 +2,6 @@
 
 var util = require('util');
 var xtend = require('xtend');
-
 var stormpath = require('stormpath');
 
 var createSession = require('../helpers/create-session');
@@ -36,18 +35,12 @@ module.exports = function (req, res, next) {
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
 
-  var accessTokenCookieName = config.web.accessTokenCookie.name;
-  var refreshTokenCookieName = config.web.refreshTokenCookie.name;
-
-  var authorizationHeader = req.headers.Authorization || req.headers.authorization || '';
 
   // In the event this has already been run (this can happen due to Express
   // routing logic) -- don't re-run this function.
   if (req.user) {
     return next();
   }
-
-  var cookies = req.cookies;
 
   var accessTokenAuthenticator = new stormpath.StormpathAccessTokenAuthenticator(client)
     .forApplication(application);
@@ -56,17 +49,19 @@ module.exports = function (req, res, next) {
     accessTokenAuthenticator.withLocalValidation();
   }
 
+  var cookies = req.cookies;
+
+  var accessTokenCookieName = config.web.accessTokenCookie.name;
   var accessTokenFromCookie = cookies && cookies[accessTokenCookieName];
 
-  var accessTokenFromHeader = authorizationHeader.match(/Bearer [^;]+/) ? authorizationHeader.split('Bearer ')[1] : null;
-
-  var resolvedAccessToken = accessTokenFromHeader || accessTokenFromCookie;
-
+  var refreshTokenCookieName = config.web.refreshTokenCookie.name;
   var refreshTokenFromCookie = cookies && cookies[refreshTokenCookieName];
 
+  var authorizationHeader = req.headers.Authorization || req.headers.authorization || '';
+  var accessTokenFromHeader = authorizationHeader.match(/Bearer [^;]+/) ? authorizationHeader.split('Bearer ')[1] : null;
+  var resolvedAccessToken = accessTokenFromHeader || accessTokenFromCookie;
 
   if (resolvedAccessToken) {
-
     accessTokenAuthenticator.authenticate(resolvedAccessToken, function (err, authenticationResult) {
       if (err) {
         logger.info('Failed to authenticate the request. Invalid access_token found.');
@@ -116,20 +111,21 @@ module.exports = function (req, res, next) {
 
       req.authenticationResult = authenticationResult;
 
-      // Backcompat: provide the expanded JWT as req.accessToken,
-      // which has the claims under the 'body' key
-
+      // Backcompat: Provide the expanded JWT as req.accessToken,
+      // which has the claims under the 'body' key.
       Object.defineProperty(req, 'accessToken', {
         get: util.deprecate(function () {
           var jwt = xtend({}, authenticationResult.expandedJwt);
           jwt.body = {};
+
           Object.keys(jwt.claims).forEach(function (key) {
             if (jwt.claims.hasOwnProperty(key)) {
               jwt.body[key] = jwt.claims[key];
             }
           });
+
           return jwt;
-        }, 'req.accessToken is deprecated, use req.authenticationResult instead')
+        }, 'req.accessToken is deprecated, use req.authenticationResult instead.')
       });
 
       authenticationResult.getAccount(function (err, account) {

--- a/lib/middleware/get-user.js
+++ b/lib/middleware/get-user.js
@@ -36,7 +36,7 @@ module.exports = function (req, res, next) {
   var accessTokenCookieName = config.web.accessTokenCookie.name;
   var refreshTokenCookieName = config.web.refreshTokenCookie.name;
 
-  var authorizationHeader = req.headers.Authoriation || req.headers.authorization || '';
+  var authorizationHeader = req.headers.Authorization || req.headers.authorization || '';
 
   // In the event this has already been run (this can happen due to Express
   // routing logic) -- don't re-run this function.

--- a/lib/middleware/get-user.js
+++ b/lib/middleware/get-user.js
@@ -64,7 +64,7 @@ module.exports = function (req, res, next) {
   if (resolvedAccessToken) {
     accessTokenAuthenticator.authenticate(resolvedAccessToken, function (err, authenticationResult) {
       if (err) {
-        logger.info('Failed to authenticate the request. Invalid access_token found.');
+        logger.info(err);
 
         if (!refreshTokenFromCookie) {
           return next();

--- a/lib/middleware/get-user.js
+++ b/lib/middleware/get-user.js
@@ -29,11 +29,14 @@ var expandAccount = require('../helpers/expand-account');
  */
 module.exports = function (req, res, next) {
   var application = req.app.get('stormpathApplication');
+  var client = req.app.get('stormpathClient');
   var config = req.app.get('stormpathConfig');
   var logger = req.app.get('stormpathLogger');
 
   var accessTokenCookieName = config.web.accessTokenCookie.name;
   var refreshTokenCookieName = config.web.refreshTokenCookie.name;
+
+  var authorizationHeader = req.headers.Authoriation || req.headers.authorization || '';
 
   // In the event this has already been run (this can happen due to Express
   // routing logic) -- don't re-run this function.
@@ -43,22 +46,35 @@ module.exports = function (req, res, next) {
 
   var cookies = req.cookies;
 
-  if (cookies && cookies[accessTokenCookieName]) {
-    var authenticator = new stormpath.JwtAuthenticator(application);
+  var accessTokenAuthenticator = new stormpath.StormpathAccessTokenAuthenticator(client)
+    .forApplicationHref(application.href);
 
-    if (config.web.oauth2.password.validationStrategy === 'local') {
-      authenticator.withLocalValidation();
-    }
+  console.log(config.web.oauth2.password.validationStrategy);
 
-    authenticator.authenticate(cookies[accessTokenCookieName], function (err, authenticationResult) {
+  if (config.web.oauth2.password.validationStrategy === 'local') {
+    accessTokenAuthenticator.withLocalValidation();
+  }
+
+  var accessTokenFromCookie = cookies && cookies[accessTokenCookieName];
+
+  var accessTokenFromHeader = authorizationHeader.match(/Bearer [^;]+/) ? authorizationHeader.split('Bearer ')[1] : null;
+
+  var resolvedAccessToken = accessTokenFromHeader || accessTokenFromCookie;
+
+  var refreshTokenFromCookie = cookies && cookies[refreshTokenCookieName];
+
+
+  if (resolvedAccessToken) {
+    debugger
+    accessTokenAuthenticator.authenticate(resolvedAccessToken, function (err, authenticationResult) {
       if (err) {
         logger.info('Failed to authenticate the request. Invalid access_token found.');
 
-        if (!cookies[refreshTokenCookieName]) {
+        if (!refreshTokenFromCookie) {
           return next();
         }
 
-        return new stormpath.OAuthRefreshTokenGrantRequestAuthenticator(application).authenticate({ refresh_token: cookies[refreshTokenCookieName] }, function (err, refreshGrantResponse) {
+        return new stormpath.OAuthRefreshTokenGrantRequestAuthenticator(application).authenticate({ refresh_token: refreshTokenFromCookie }, function (err, refreshGrantResponse) {
           if (err) {
             logger.info('Failed to refresh an access_token given a refresh_token.');
             return next();
@@ -97,7 +113,8 @@ module.exports = function (req, res, next) {
         });
       }
 
-      req.accessToken = authenticationResult.accessToken;
+      req.accessToken = authenticationResult;
+      req.authenticationResult = authenticationResult;
       authenticationResult.getAccount(function (err, account) {
         if (err) {
           logger.info('Failed to get account ' + authenticationResult.account.href);
@@ -128,7 +145,7 @@ module.exports = function (req, res, next) {
         });
       });
     });
-  } else if (cookies && cookies[refreshTokenCookieName]) {
+  } else if (refreshTokenFromCookie) {
     new stormpath.OAuthRefreshTokenGrantRequestAuthenticator(application).authenticate({ refresh_token: cookies[refreshTokenCookieName] }, function (err, refreshGrantResponse) {
       if (err) {
         logger.info('Failed to refresh an access_token given a refresh_token.');
@@ -167,6 +184,7 @@ module.exports = function (req, res, next) {
       });
     });
   } else {
+    // At this point, I believe this is only handling Basic auth requests
     application.authenticateApiRequest({ request: req }, function (err, result) {
       if (err) {
         logger.info('Failed to authenticate the incoming request.');

--- a/lib/middleware/get-user.js
+++ b/lib/middleware/get-user.js
@@ -64,6 +64,9 @@ module.exports = function (req, res, next) {
   if (resolvedAccessToken) {
     accessTokenAuthenticator.authenticate(resolvedAccessToken, function (err, authenticationResult) {
       if (err) {
+
+        req.authenticationError = err;
+
         logger.info(err);
 
         if (!refreshTokenFromCookie) {

--- a/lib/middleware/get-user.js
+++ b/lib/middleware/get-user.js
@@ -116,13 +116,7 @@ module.exports = function (req, res, next) {
       Object.defineProperty(req, 'accessToken', {
         get: util.deprecate(function () {
           var jwt = xtend({}, authenticationResult.expandedJwt);
-          jwt.body = {};
-
-          Object.keys(jwt.claims).forEach(function (key) {
-            if (jwt.claims.hasOwnProperty(key)) {
-              jwt.body[key] = jwt.claims[key];
-            }
-          });
+          jwt.body = xtend({}, jwt.claims);
 
           return jwt;
         }, 'req.accessToken is deprecated, use req.authenticationResult instead.')

--- a/lib/middleware/get-user.js
+++ b/lib/middleware/get-user.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var util = require('util');
+var xtend = require('xtend');
+
 var stormpath = require('stormpath');
 
 var createSession = require('../helpers/create-session');
@@ -111,8 +114,24 @@ module.exports = function (req, res, next) {
         });
       }
 
-      req.accessToken = authenticationResult;
       req.authenticationResult = authenticationResult;
+
+      // Backcompat: provide the expanded JWT as req.accessToken,
+      // which has the claims under the 'body' key
+
+      Object.defineProperty(req, 'accessToken', {
+        get: util.deprecate(function () {
+          var jwt = xtend({}, authenticationResult.expandedJwt);
+          jwt.body = {};
+          Object.keys(jwt.claims).forEach(function (key) {
+            if (jwt.claims.hasOwnProperty(key)) {
+              jwt.body[key] = jwt.claims[key];
+            }
+          });
+          return jwt;
+        }, 'req.accessToken is deprecated, use req.authenticationResult instead')
+      });
+
       authenticationResult.getAccount(function (err, account) {
         if (err) {
           logger.info('Failed to get account ' + authenticationResult.account.href);

--- a/lib/middleware/get-user.js
+++ b/lib/middleware/get-user.js
@@ -47,9 +47,7 @@ module.exports = function (req, res, next) {
   var cookies = req.cookies;
 
   var accessTokenAuthenticator = new stormpath.StormpathAccessTokenAuthenticator(client)
-    .forApplicationHref(application.href);
-
-  console.log(config.web.oauth2.password.validationStrategy);
+    .forApplication(application);
 
   if (config.web.oauth2.password.validationStrategy === 'local') {
     accessTokenAuthenticator.withLocalValidation();
@@ -65,7 +63,7 @@ module.exports = function (req, res, next) {
 
 
   if (resolvedAccessToken) {
-    debugger
+
     accessTokenAuthenticator.authenticate(resolvedAccessToken, function (err, authenticationResult) {
       if (err) {
         logger.info('Failed to authenticate the request. Invalid access_token found.');

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -2,6 +2,7 @@
 
 var cookieParser = require('cookie-parser');
 var express = require('express');
+var util = require('util');
 var winston = require('winston');
 
 var controllers = require('./controllers');
@@ -204,7 +205,7 @@ module.exports.init = function (app, opts) {
     }
 
     if (web.me.enabled) {
-      router.get(web.me.uri, stormpathMiddleware, middleware.loginRequired, controllers.currentUser);
+      router.get(web.me.uri, stormpathMiddleware, middleware.authenticationRequired, controllers.currentUser);
     }
 
     if (web.oauth2.enabled) {
@@ -244,7 +245,7 @@ function getUserMiddlewareProxy(nextMiddleware) {
  *
  * @property loginRequired
  */
-module.exports.loginRequired = getUserMiddlewareProxy(middleware.loginRequired);
+module.exports.loginRequired = util.deprecate(getUserMiddlewareProxy(middleware.loginRequired), 'loginRequired is deprecated, please use authenticationRequired instead.');
 
 /**
  * Expose the `getUser` middleware.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "accounts"
   ],
   "scripts": {
-    "docs": "cd docs && rm -rf _build/html && make html && jsdoc -d ./apidocs/ -P ./package.json -r .",
+    "docs": "cd docs && rm -rf _build/html && make html",
     "lint": "./node_modules/eslint/bin/eslint.js -c .eslintrc lib/** test/** --ignore-pattern **/*.yml --quiet",
     "test": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha --check-leaks --report html -- --reporter spec --recursive --growl --no-timeouts",
     "test-travis": "npm run lint && istanbul cover ./node_modules/mocha/bin/_mocha --check-leaks --report lcovonly -- --reporter spec --recursive --no-timeouts"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "parse-iso-duration": "^1.0.0",
     "qs": "^6.0.2",
     "request": "^2.63.0",
-    "stormpath": "0.19.x",
+    "stormpath": "0.20.x",
     "stormpath-config": "0.0.27",
     "utils-merge": "^1.0.0",
     "uuid": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "stormpath-config": "0.0.27",
     "utils-merge": "^1.0.0",
     "uuid": "^2.0.1",
-    "winston": "^2.1.1"
+    "winston": "^2.1.1",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "cheerio": "^0.22.0",

--- a/test/middlewares/test-get-user.js
+++ b/test/middlewares/test-get-user.js
@@ -491,6 +491,23 @@ describe('getUser', function () {
             .end(callback);
         },
         function (callback) {
+          // The first authentication attempt will take longer, because we have to fetch the
+          // access token resources
+          var a = new Date();
+          agent
+            .get('/')
+            .expect(200)
+            .end(function (err, res) {
+              if (err) {
+                return callback(err);
+              }
+              var b = new Date();
+              assert((b - a) > 100, 'Expected first validation attempt to take some time, due to fetching access token resource');
+              assert.equal(res.body.email, accountData.email);
+              callback();
+            });
+        },
+        function (callback) {
           var a = new Date();
           agent
             .get('/')

--- a/test/middlewares/test-get-user.js
+++ b/test/middlewares/test-get-user.js
@@ -406,7 +406,7 @@ describe('getUser', function () {
     });
   });
 
-  it('should set req.user and res.locals.user if an access_token cookie is present and valid', function (done) {
+  it('should set req.user, res.locals.user, res.authenticationResult, res.accessToken if an access_token cookie is present and valid', function (done) {
     var app = createFakeExpressApp();
     var agent = request.agent(app);
 
@@ -415,7 +415,8 @@ describe('getUser', function () {
       assert.equal(req.user.givenName, accountData.givenName);
       assert.equal(req.user.surname, accountData.surname);
       assert.equal(req.user.email, accountData.email);
-
+      assert.equal(req.accessToken.body.sub, stormpathAccount.href);
+      assert.equal(req.authenticationResult.account.href, stormpathAccount.href);
       res.send('success');
     });
 


### PR DESCRIPTION
**Work In Progress**

Updates this library to use the new `StormpathAccessTokenAuthenticator`, in a backwards-compatible way, so that we can release a patch release that will allow this library to properly authenticate access tokens that are issued by the Client API.

Depends on the `access-token-authenticator` branch in the Node SDK, as seen in this PR:

https://github.com/stormpath/stormpath-sdk-node/pull/597

Todo:

- [x] Update authentication and authorization docs to discuss Client API and be clearer about how to use our access tokens.