### PR TITLE
Config-loading tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "coveralls": "^2.11.2",
     "eslint": "^2.13.1",
     "istanbul": "^0.4.0",
-    "js-yaml": "^3.5.4",
+    "js-yaml": "^3.8.1",
     "mocha": "^3.0.2",
     "mocha-lcov-reporter": "^1.0.0",
     "sinon": "^1.17.3",

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,255 @@
+'use strict';
+
+var assert = require('assert');
+var fs = require('fs');
+var FakeFs = require('fake-fs');
+var path = require('path');
+var yaml = require('js-yaml');
+var extend = require('xtend');
+
+var helpers = require('./helpers');
+var clientFactory = require('../lib/client');
+
+var defaultConfigPath = path.resolve(__dirname, '../lib/config.yml');
+
+function createHomeConfig(callback) {
+  var client = helpers.createClient();
+  helpers.createApplication(client, function (err, application) {
+    if (err) {
+      return callback(err);
+    }
+
+    application.createAccount(helpers.newUser(), function (err, account) {
+      if (err) {
+        return callback(err);
+      }
+
+      account.createApiKey(function (err, apiKey) {
+        if (err) {
+          return callback(err);
+        }
+
+        var config = {
+          client: {
+            apiKey: {
+              id: apiKey.id,
+              secret: apiKey.secret
+            }
+          },
+          application: {
+            href: application.href
+          }
+        };
+
+        callback(null, {
+          config: config,
+          application: application
+        });
+      });
+    });
+  });
+}
+
+function cleanEnv() {
+  var restore = helpers.snapshotEnv();
+
+  for (var key in process.env) {
+    if (key.indexOf('STORMPATH_') === 0) {
+      delete process.env[key];
+    }
+  }
+
+  return restore;
+}
+
+function getDefaultConfig() {
+  return fs.readFileSync(defaultConfigPath);
+}
+
+function getDefaultYaml() {
+  return yaml.load(getDefaultConfig(), 'utf-8');
+}
+
+function getClient(options, done) {
+  var client = clientFactory(options || {});
+
+  client.on('ready', function () {
+    done();
+  });
+
+  client.on('error', done);
+
+  return client;
+}
+
+function mockCommonPaths(fakeFs) {
+  var dynamicRequires = [
+    '/resource/Application.js',
+    '/resource/ApplicationAccountStoreMapping.js',
+    '/resource/AccountStoreMapping.js',
+    '/resource/PasswordResetToken.js',
+    '/authc/AuthRequestParser.js',
+    '/authc/BasicApiAuthenticator.js',
+    '/authc/OAuthBasicExchangeAuthenticator.js',
+    '/error/messages.js'
+  ];
+
+  fakeFs.file(defaultConfigPath, {content: getDefaultConfig()});
+  fakeFs.file(process.cwd() + '/node_modules/stormpath/lib/config.yml', {
+    content: fs.readFileSync(process.cwd() + '/node_modules/stormpath/lib/config.yml')
+  });
+
+  dynamicRequires.forEach(function (filePath) {
+    fakeFs.file(process.cwd() + '/node_modules/stormpath/lib' + filePath, {
+      content: fs.readFileSync(process.cwd() + '/node_modules/stormpath/lib' + filePath)
+    });
+  });
+}
+
+describe('configuration loading', function () {
+  var restoreEnv;
+  var fakeFs;
+  var homeConfig;
+  var application;
+
+  before(function (done) {
+    createHomeConfig(function (err, data) {
+      if (err) {
+        return done(err);
+      }
+
+      homeConfig = data.config;
+      application = data.application;
+      done();
+    });
+  });
+
+  after(function (done) {
+    application.delete(done);
+  });
+
+  beforeEach(function () {
+    restoreEnv = cleanEnv();
+
+    if (fakeFs) {
+      fakeFs.unpatch();
+    }
+
+    fakeFs = new FakeFs().bind();
+  });
+
+  afterEach(function () {
+    restoreEnv();
+  });
+
+  describe('loading of default YAML configuration', function () {
+    var yamlData;
+    var client;
+
+    beforeEach(function (done) {
+      var config = extend({}, homeConfig, {skipRemoteConfig: true});
+      yamlData = getDefaultYaml();
+      client = getClient(config, done);
+
+      mockCommonPaths(fakeFs);
+
+      fakeFs.patch();
+    });
+
+    it('should contain the default configuration fields', function () {
+      assert(helpers.contains(client.config, yamlData));
+    });
+  });
+
+  describe('loading a custom stormpath.yml', function () {
+    var client;
+
+    beforeEach(function (done) {
+      var config = extend({}, homeConfig, {skipRemoteConfig: true});
+      mockCommonPaths(fakeFs);
+      fakeFs.file(process.cwd() + '/stormpath.yml', {
+        content: yaml.dump({
+          web: {
+            invented: {
+              testable: true
+            }
+          }
+        })
+      });
+
+      fakeFs.patch();
+
+      client = getClient(config, done);
+    });
+
+    afterEach(function () {
+      fakeFs.unpatch();
+    });
+
+    it('should contain the loaded data', function () {
+      assert('web' in client.config);
+      assert('invented' in client.config.web);
+      assert('testable' in client.config.web.invented);
+      assert.equal(client.config.web.invented.testable, true);
+    });
+  });
+
+  describe('loading of custom stormpath.json', function () {
+    var client;
+
+    beforeEach(function (done) {
+      var config = extend({}, homeConfig, {skipRemoteConfig: true});
+      mockCommonPaths(fakeFs);
+      fakeFs.file(process.cwd() + '/stormpath.json', {
+        content: JSON.stringify({
+          web: {
+            invented: {
+              untestable: 'yeah'
+            }
+          }
+        })
+      });
+
+      fakeFs.patch();
+
+      client = getClient(config, done);
+    });
+
+    afterEach(function () {
+      fakeFs.unpatch();
+    });
+
+    it('should contain the loaded data', function () {
+      assert('web' in client.config);
+      assert('invented' in client.config.web);
+      assert('untestable' in client.config.web.invented);
+      assert.equal(client.config.web.invented.untestable, 'yeah');
+    });
+  });
+
+  describe('loading configuration from the environment', function () {
+
+  });
+
+  describe('loading configuration from .init()', function () {
+
+  });
+
+  describe('loading configuration that is resolved at runtime', function () {
+
+  });
+
+  describe('detecting invalid configurations', function () {
+    it('should abort if the stormpath id is not specified', function () {
+
+    });
+
+    it('should abort if the stormpath secret is not specified', function () {
+
+    });
+
+    it('should abort if the application id is not specified', function () {
+
+    });
+  });
+});

--- a/test/config.js
+++ b/test/config.js
@@ -228,11 +228,65 @@ describe('configuration loading', function () {
   });
 
   describe('loading configuration from the environment', function () {
+    var client;
 
+    beforeEach(function (done) {
+      process.env.STORMPATH_CLIENT_APIKEY_ID = homeConfig.client.apiKey.id;
+      process.env.STORMPATH_CLIENT_APIKEY_SECRET = homeConfig.client.apiKey.secret;
+      process.env.STORMPATH_APPLICATION_HREF = application.href;
+
+      var config = extend({}, {skipRemoteConfig: true});
+      mockCommonPaths(fakeFs);
+
+      fakeFs.patch();
+
+      client = getClient(config, done);
+    });
+
+    afterEach(function () {
+      fakeFs.unpatch();
+    });
+
+    it('should load the configuration from the environment', function () {
+      assert('client' in client.config);
+      assert('apiKey' in client.config.client);
+      assert.equal(client.config.client.apiKey.id, homeConfig.client.apiKey.id);
+      assert.equal(client.config.client.apiKey.secret, homeConfig.client.apiKey.secret);
+
+      assert('application' in client.config);
+      assert.equal(client.config.application.href, homeConfig.application.href);
+    });
   });
 
   describe('loading configuration from .init()', function () {
+    var client;
+    var extraInitConfig;
 
+    beforeEach(function (done) {
+      extraInitConfig = {
+        web: {
+          initStuff: {
+            name: 'some very good name'
+          }
+        }
+      };
+
+      var config = extend(extraInitConfig, homeConfig, {skipRemoteConfig: true});
+      mockCommonPaths(fakeFs);
+
+      fakeFs.patch();
+
+      client = getClient(config, done);
+    });
+
+    afterEach(function () {
+      fakeFs.unpatch();
+    });
+
+    it('should load the configuration from the config init object', function () {
+      assert('initStuff' in client.config.web);
+      assert.equal(client.config.web.initStuff.name, extraInitConfig.web.initStuff.name);
+    });
   });
 
   describe('loading configuration that is resolved at runtime', function () {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -223,3 +223,66 @@ module.exports.noOpLogger = {
   info: function () {},
   error: function () {}
 };
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function isObject(target) {
+  return Object.prototype.toString.call(target) === '[object Object]';
+}
+
+function isArray(target) {
+  return Object.prototype.toString.call(target) === '[object Array]';
+}
+
+/**
+ * Takes a snapshot of the current state of the env variables, and Returns
+ * a function that can be used to restore it.
+ */
+module.exports.snapshotEnv = function snapshotEnv() {
+  var originalEnv = clone(process.env);
+  return function restore() {
+    var key;
+    for (key in process.env) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (key in originalEnv) {
+      process.env[key] = originalEnv[key];
+    }
+  };
+};
+
+module.exports.contains = function contains(container, containee) {
+  if ((!containee || !container) && containee !== container) {
+    return false;
+  }
+
+  if (isArray(containee)) {
+    return containee.reduce(function (acc, value) {
+      return acc && container.indexOf && container.indexOf(value) !== -1;
+    }, true);
+  }
+
+  if (isObject(containee)) {
+    for (var key in containee) {
+      var doesContain;
+
+      if (isObject(containee[key]) || isArray(containee[key])) {
+        doesContain = contains(container[key], containee[key]);
+      } else {
+        doesContain = container[key] === containee[key];
+      }
+
+      if (!doesContain) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  return container === containee;
+};


### PR DESCRIPTION
Adds tests for config loading. Tests these features:

  * Is config loaded from the default config.yml
  * Is config loaded from a local stormpath.yml
  * Is config loaded from a local stormpath.json
  * Is config loaded from the environment
  * Is config loaded from the config object
  * Is configuration overridden in the proper order
  * Are errors thrown if the id/secret/app_href are missing

Needs a tiny bit more work, however - when testing the application href missing line, the application is complaining that the ID/Secret are incorrect, after being generated for a new account created for that very application. Spent some time trying to track it, but running into a wall. Maybe a fresh pair of eyes would be helpful.

Fixes #286 