### PR TITLE
Update protected route middleware docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ Follow these steps to add Stormpath user authentication to your Express.js app.
     //...
   });
   ```
+  
+  The `stormpath.authenticationRequired` middleware depends on the `cookie-parser` middleware, make sure that you are including the `cookie-parser` prior to all of your secured routes:
+
+  ```javascript
+  var express = require('express');
+  var stormpath = require('express-stormpath');
+  var cookieParser = require('cookie-parser');
+
+  var app = express();
+
+  // Include the cookier-parser middleware prior to securing the route with 'stormpath.authenticationRequired'
+  app.use(cookieParser());
+  app.use(stormpath.init(application, stormpathConfiguration));
+
+
+  app.get('/secret', stormpath.authenticationRequired, function(req, res){ 
+    //...
+  });
+  ```
 
   For API services that use HTTP Basic Auth, use
   `stormpath.apiAuthenticationRequired`:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Change Log
 
 All library changes, in descending order.
 
+Version 3.2.1
+-------------
+
+- Updated documentation to reference cookie-parser dependency when using `stormpath.authenticationRequired` middleware
+
 Version 3.2.0
 -------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-stormpath",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Build simple, secure web applications with Stormpath and Express!",
   "keywords": [
     "express",


### PR DESCRIPTION
- The stormpath middleware, _stormpath.authenticationRequired_, depends
  on cookie-parser being defined.  Cookie-parser will attach cookies
  from the request and attach them to the canonical req object in
  express.  This property is then used by the middelware to verify
  the authenticity of the user and properly secure the route.

- This commit provides additional requirements to users who are
  leveraging the authenticationRequired middleware

Closes #602