### PR TITLE
next URI must be encoded in the form action for query strings to work…

### DIFF
--- a/lib/controllers/login.js
+++ b/lib/controllers/login.js
@@ -81,7 +81,7 @@ module.exports = function (req, res, next) {
       },
       'text/html': function () {
         var nextUri = url.parse(req.query.next || '').path;
-        var formActionUri = (config.web.login.uri + (nextUri ? ('?next=' + nextUri) : ''));
+        var formActionUri = (config.web.login.uri + (nextUri ? ('?next=' + encodeURIComponent(nextUri)) : ''));
 
         if (req.user && config.web.login.enabled) {
           var nextUrl = nextUri || config.web.login.nextUri;


### PR DESCRIPTION
… on redirect.

formAction is not encoded.  So if your next URI has a query string, its then a query string in side a query string and breaks.  Wrapping in encodeURIComponent fixes.  Please pull.