### PR TITLE
Fixed get user auth priority - first check cookie and then header for…

### DIFF
--- a/lib/middleware/get-user.js
+++ b/lib/middleware/get-user.js
@@ -62,7 +62,7 @@ module.exports = function (req, res, next) {
 
   var authorizationHeader = req.headers.Authorization || req.headers.authorization || '';
   var accessTokenFromHeader = authorizationHeader.match(/Bearer [^;]+/) ? authorizationHeader.split('Bearer ')[1] : null;
-  var resolvedAccessToken = accessTokenFromHeader || accessTokenFromCookie;
+  var resolvedAccessToken =  accessTokenFromCookie || accessTokenFromHeader;
 
   if (resolvedAccessToken) {
     accessTokenAuthenticator.authenticate(resolvedAccessToken, function (err, authenticationResult) {


### PR DESCRIPTION
Migration from Stormpath to Okta:

When checking authenticationRequired route the resolvedAccessToken should take the access token from cookie first.

This scenario is happen when the request contains the cookies together with Auth Bearer and then the auth failed